### PR TITLE
Persistence Layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .env.test.local
 .env.production.local
 .idea
+medmorph.db
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -9,6 +9,33 @@ Reference implementation of the MedMorph Backend Service Client
 https://build.fhir.org/ig/HL7/fhir-medmorph/index.html
 
 
+## Running the Client
+
+The Backend Service Client is provided as a NodeJS Express app. NodeJS is required to to run the app.
+
+```sh
+git clone https://github.com/mcode/medmorph-backend
+cd medmorph-backend
+npm install
+npm start
+```
+
+With default settings, the app will now be running at `http://localhost:3000`
+
+Certain configuration properties may be set in an environment file, `.env`:
+
+```env
+# Port number for the server, defaults to 3000 if not provided
+PORT=3001
+
+# Enabled debug loggers
+# The app uses the debug library, see: https://github.com/visionmedia/debug
+# "The DEBUG environment variable is then used to enable these based on space or comma-delimited names."
+# Enable all express loggers with DEBUG=*
+# Enable all loggers for just the app with DEBUG=medmorph-backend:*
+DEBUG=medmorph-backend:*
+```
+
 # License
 Copyright 2020 The MITRE Corporation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2613,6 +2613,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.1.4.tgz",
+      "integrity": "sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg=="
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -5507,9 +5512,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3628,6 +3628,11 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lokijs": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.11.tgz",
+      "integrity": "sha512-YYyuBPxMn/oS0tFznQDbIX5XL1ltMcwFqCboDr8voYE4VCDzR5vAsrvQDhlnua4lBeqMqHmLvUXRTmRUzUKH1Q=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "MedMorph Backend Service Client",
   "scripts": {
     "start": "node ./bin/www",
+    "debug": "node --inspect-brk ./bin/www",
     "test": "jest",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "lint": "eslint './src/**/*.{js,jsx}'",
@@ -24,6 +25,7 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "express": "^4.17.1",
+    "lokijs": "^1.5.11",
     "morgan": "~1.9.1"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "express": "^4.17.1",
+    "http-status-codes": "^2.1.4",
     "lokijs": "^1.5.11",
-    "morgan": "~1.9.1"
+    "morgan": "~1.9.1",
+    "uuid": "^8.3.2"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/app.js
+++ b/src/app.js
@@ -4,11 +4,14 @@ const express = require('express');
 const logger = require('morgan');
 
 const indexRouter = require('./routes/index');
+const serversRouter = require('./routes/servers');
 
 const app = express();
 
 app.use(logger('dev'));
+app.use(express.json());
 
 app.use('/', indexRouter);
+app.use('/servers/', serversRouter);
 
 module.exports = app;

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -1,3 +1,6 @@
+const { v4: uuidv4 } = require('uuid');
+const { StatusCodes } = require('http-status-codes');
+
 const express = require('express');
 const router = express.Router();
 
@@ -12,16 +15,6 @@ router.get('/', (req, res) => {
   res.send(result);
 });
 
-// https://stackoverflow.com/a/2117523
-// replace this with a real library if we find more uses for uuids
-function uuidv4() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    const r = (Math.random() * 16) | 0,
-      v = c == 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
-
 // POST /
 // Add a new server
 router.post('/', (req, res) => {
@@ -32,7 +25,7 @@ router.post('/', (req, res) => {
   }
 
   db.insert(COLLECTION, newItem);
-  res.sendStatus(201);
+  res.status(StatusCodes.CREATED).send(newItem);
 });
 
 // GET /:id
@@ -43,7 +36,7 @@ router.get('/:id', (req, res) => {
   if (resultList[0]) {
     res.send(resultList[0]);
   } else {
-    res.sendStatus(404);
+    res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
 });
 
@@ -51,7 +44,7 @@ router.get('/:id', (req, res) => {
 // update
 router.put('/:id', (req, res) => {
   if (req.params.id !== req.body.id) {
-    res.status(409).send(`server id does not match URL id`);
+    res.status(StatusCodes.CONFLICT).send(`server id does not match URL id`);
     return;
   }
 
@@ -64,7 +57,7 @@ router.put('/:id', (req, res) => {
     s => s.id === id,
     s => Object.assign(s, req.body)
   );
-  res.sendStatus(200);
+  res.sendStatus(StatusCodes.OK); // 200
 });
 
 // DELETE /:id
@@ -72,7 +65,7 @@ router.put('/:id', (req, res) => {
 router.delete('/:id', (req, res) => {
   const id = req.params.id;
   db.delete(COLLECTION, s => s.id === id);
-  res.sendStatus(200);
+  res.sendStatus(StatusCodes.OK);
 });
 
 module.exports = router;

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -1,0 +1,78 @@
+const express = require('express');
+const router = express.Router();
+
+const db = require('../storage/DataAccess');
+
+const COLLECTION = 'servers';
+
+// GET /
+// List all servers
+router.get('/', (req, res) => {
+  const result = db.select(COLLECTION, () => true);
+  res.send(result);
+});
+
+// https://stackoverflow.com/a/2117523
+// replace this with a real library if we find more uses for uuids
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = (Math.random() * 16) | 0,
+      v = c == 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// POST /
+// Add a new server
+router.post('/', (req, res) => {
+  const newItem = req.body;
+
+  if (!newItem.id) {
+    newItem.id = uuidv4();
+  }
+
+  db.insert(COLLECTION, newItem);
+  res.sendStatus(201);
+});
+
+// GET /:id
+// Read a single server
+router.get('/:id', (req, res) => {
+  const id = req.params.id;
+  const resultList = db.select(COLLECTION, s => s.id === id);
+  if (resultList[0]) {
+    res.send(resultList[0]);
+  } else {
+    res.sendStatus(404);
+  }
+});
+
+// PUT /:id
+// update
+router.put('/:id', (req, res) => {
+  if (req.params.id !== req.body.id) {
+    res.status(409).send(`server id does not match URL id`);
+    return;
+  }
+
+  // NOTE - this assumes the entry already exists
+  // for a more rigorous API we should either check first,
+  // or use an "upsert"-type function within the DB
+  const id = req.params.id;
+  db.update(
+    COLLECTION,
+    s => s.id === id,
+    s => Object.assign(s, req.body)
+  );
+  res.sendStatus(200);
+});
+
+// DELETE /:id
+// Remove a server
+router.delete('/:id', (req, res) => {
+  const id = req.params.id;
+  db.delete(COLLECTION, s => s.id === id);
+  res.sendStatus(200);
+});
+
+module.exports = router;

--- a/src/storage/DataAccess.js
+++ b/src/storage/DataAccess.js
@@ -1,0 +1,42 @@
+/**
+ * DataAccess API:
+ *
+ * The goal of the DataAccess class is to abstract away differences
+ * between, e.g., an in-memory-only database and a full DB client.
+ * However our choice of in-memory db may already align with a DB,
+ * so rather than just invent new terms for their own sake,
+ * this API may look very similar to a Mongo/LokiJS API.
+ *
+ *
+ * Create:
+ * - insert(collectionName, value)
+ *   @param {string} collectionName - name of the collection to add to
+ *   @param {object|array} value - object to add, or array of objects to add
+ *   @return {void}
+ *
+ * Read:
+ * - select(collectionName, whereFn)
+ *   @param {string} collectionName - name of the collection to search
+ *   @param {function(object): boolean} whereFn - function to filter results by
+ *   @return {array} - array of matching objects
+ *
+ * Update:
+ * - update(collectionName, whereFn, updateFn)
+ *   @param {string} collectionName - name of collection to update
+ *   @param {function(object): boolean} whereFn - function to identify rows to update
+ *   @param {function(object): void} updateFn - function to apply to matching rows
+ *   @return {void}
+ *
+ * Delete:
+ * - delete(collectionName, whereFn)
+ *   @param {string} collectionName - name of collection to delete from
+ *   @param {function(object): boolean} whereFn - function to identify rows to delete
+ *   @return {void}
+ */
+
+// TODO: eventually we want some kind of config setting to choose the impl
+const Internal = require('./impl/Internal');
+
+const instance = new Internal();
+
+module.exports = instance;

--- a/src/storage/__tests__/DataAccess.test.js
+++ b/src/storage/__tests__/DataAccess.test.js
@@ -1,0 +1,17 @@
+const db = require('../DataAccess');
+
+describe('Test the internal data store', () => {
+  test('It should expose the proper api', () => {
+    expect(typeof db.insert).toEqual('function');
+    expect(db.insert).toHaveLength(2); // function.length == number of args
+
+    expect(typeof db.select).toEqual('function');
+    expect(db.select).toHaveLength(2);
+
+    expect(typeof db.update).toEqual('function');
+    expect(db.update).toHaveLength(3);
+
+    expect(typeof db.delete).toEqual('function');
+    expect(db.delete).toHaveLength(2);
+  });
+});

--- a/src/storage/impl/Internal.js
+++ b/src/storage/impl/Internal.js
@@ -58,6 +58,7 @@ class Internal {
   delete(collectionName, whereFn) {
     const collection = this._getCollection(collectionName);
     collection.removeWhere(whereFn);
+    // note that this does not return anything. we may need to update that at some point
   }
 }
 

--- a/src/storage/impl/Internal.js
+++ b/src/storage/impl/Internal.js
@@ -1,0 +1,64 @@
+/*
+ * Options for an in-memory database include:
+ * - TingoDB: https://github.com/sergeyksv/tingodb
+ * - NeDB: https://github.com/louischatriot/nedb
+ * - LokiJS: https://github.com/techfort/LokiJS
+ * - lowdb: https://github.com/typicode/lowdb
+ *
+ * However most of these are not actively maintained.
+ * I'm using LokiJS here because it does still see some active development.
+ * Documentation is at http://techfort.github.io/LokiJS/
+ */
+
+const loki = require('lokijs');
+
+const isTest = process.env.NODE_ENV === 'test';
+
+class Internal {
+  constructor(persist = !isTest) {
+    // By default, persist unless we are in the test environment.
+    // But this can be overridden by the given arg.
+    if (persist) {
+      this.db = new loki('medmorph.db', {
+        autoload: true,
+        autosave: true,
+        serializationMethod: 'pretty'
+      });
+    } else {
+      this.db = new loki('medmorph.db');
+    }
+  }
+
+  _getCollection(c) {
+    let collection = this.db.getCollection(c);
+    if (collection === null) {
+      collection = this.db.addCollection(c, { disableMeta: true });
+      // unfortunately LokiJS adds a "meta" field for metadata,
+      // which could collide with the "meta" field on a FHIR resource
+      // for now, just disable the LokiJS metadata, we don't need it
+    }
+    return collection;
+  }
+
+  insert(collectionName, value) {
+    const collection = this._getCollection(collectionName);
+    collection.insert(value); // may be a single object, or an array
+  }
+
+  select(collectionName, whereFn) {
+    const collection = this._getCollection(collectionName);
+    return collection.where(whereFn);
+  }
+
+  update(collectionName, whereFn, updateFn) {
+    const collection = this._getCollection(collectionName);
+    collection.updateWhere(whereFn, updateFn);
+  }
+
+  delete(collectionName, whereFn) {
+    const collection = this._getCollection(collectionName);
+    collection.removeWhere(whereFn);
+  }
+}
+
+module.exports = Internal; /* constructor */

--- a/src/storage/impl/__tests__/Internal.test.js
+++ b/src/storage/impl/__tests__/Internal.test.js
@@ -1,0 +1,54 @@
+const Internal = require('../Internal');
+
+describe('Test the internal data store', () => {
+  test('It should not find objects that do not exist', () => {
+    const db = new Internal(false);
+    const result = db.select('stuff', row => row.name === 'jane doe');
+    expect(result).toStrictEqual([]); // note empty array, not null
+  });
+
+  test('It should support inserting then querying a new object', () => {
+    const db = new Internal(false);
+    let result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toStrictEqual([]);
+    db.insert('stuff', { id: 1, name: 'john doe', email: 'jdoe@example.com' });
+
+    result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 1, name: 'john doe', email: 'jdoe@example.com' });
+    // note no strict equality test; the result contains a $loki field as well
+  });
+
+  test('It should support updating an object', () => {
+    const db = new Internal(false);
+    let result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toStrictEqual([]);
+    db.insert('stuff', { id: 1, name: 'john doe', email: 'jdoe@example.com' });
+
+    db.update(
+      'stuff',
+      row => row.name === 'john doe',
+      row => (row.email = 'john_doe@example.com')
+    );
+
+    result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toMatchObject({ id: 1, name: 'john doe', email: 'jdoe@example.com' });
+    expect(result[0]).toMatchObject({ id: 1, name: 'john doe', email: 'john_doe@example.com' });
+  });
+
+  test('It should support deleting an object', () => {
+    const db = new Internal(false);
+    let result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toStrictEqual([]);
+    db.insert('stuff', { id: 1, name: 'john doe', email: 'jdoe@example.com' });
+
+    result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toHaveLength(1);
+
+    db.delete('stuff', row => row.id === 1);
+
+    result = db.select('stuff', row => row.name === 'john doe');
+    expect(result).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
Adds a "persistence layer" to the app, with an initial implementation of an in-memory DB with LokiJS. 
https://github.com/techfort/LokiJS

The starting API is very simple and inspired by SQL concepts:
- `select(collection, whereFn)`
- `insert(collection, value)`
- `update(collection, whereFn, updateFn)`
- `delete(collection, whereFn)`

By default, running the app in dev or production mode will persist the db to a file `medmorph.db`, autosaving every 5 seconds and loading at startup. In test mode, it will be in-memory only.

I also added the `/servers/` endpoint to exercise the database. It supports simple CRUD. (I chose "servers" on the assumption we'll probably need a "servers" collection for persisting auth credentials, see MEDMORPH-27. I don't think we'll need this API to be anything special, so we can leave it or delete it once we have more meaningful APIs in place)
