### PR TITLE
accept subscriptions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,16 +2,21 @@ require('dotenv').config();
 
 const express = require('express');
 const logger = require('morgan');
+const bodyParser = require('body-parser');
 
 const indexRouter = require('./routes/index');
 const serversRouter = require('./routes/servers');
+const subscriptionsRouter = require('./routes/subscriptions');
 
 const app = express();
 
 app.use(logger('dev'));
 app.use(express.json());
+app.use(bodyParser.json({
+    type: ['application/json', 'application/fhir+json']
+  }))
 
 app.use('/', indexRouter);
 app.use('/servers/', serversRouter);
-
+app.use('/notif/', subscriptionsRouter);
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -12,9 +12,7 @@ const app = express();
 
 app.use(logger('dev'));
 app.use(express.json());
-app.use(bodyParser.json({
-    type: ['application/json', 'application/fhir+json']
-  }))
+app.use(bodyParser.json({ type: ['application/json', 'application/fhir+json'] }));
 
 app.use('/', indexRouter);
 app.use('/servers/', serversRouter);

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -13,6 +13,8 @@ router.post('/:id', (req, res) => {
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
     usePlanDef(planDef);
+  } else {
+    res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
 });
 
@@ -24,6 +26,8 @@ router.put('/:id/:resource/:resourceId', (req, res) => {
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
     usePlanDef(planDef, req.body);
+  } else {
+    res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
 });
 
@@ -35,7 +39,7 @@ function getPlanDef(id, res) {
   if (resultList[0]) {
     return resultList[0];
   } else {
-    res.sendStatus(StatusCodes.NOT_FOUND); // 404
+      return null;
   }
 }
 

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -3,7 +3,7 @@ const { StatusCodes } = require('http-status-codes');
 const express = require('express');
 const router = express.Router();
 const db = require('../storage/DataAccess');
-const COLLECTION = 'plandefs';
+const COLLECTION = 'plandefinitions';
 
 // POST /
 // Recieve subscription notification

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -9,7 +9,7 @@ const COLLECTION = 'plandefs';
 // Recieve subscription notification
 router.post('/:id', (req, res) => {
   const id = req.params.id;
-  const planDef = getPlanDef(id.res);
+  const planDef = getPlanDef(id);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
     usePlanDef(planDef);
@@ -22,7 +22,7 @@ router.post('/:id', (req, res) => {
 // will be a PUT instead of a POST
 router.put('/:id/:resource/:resourceId', (req, res) => {
   const id = req.params.id;
-  const planDef = getPlanDef(id, res);
+  const planDef = getPlanDef(id);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
     usePlanDef(planDef, req.body);
@@ -31,7 +31,7 @@ router.put('/:id/:resource/:resourceId', (req, res) => {
   }
 });
 
-function getPlanDef(id, res) {
+function getPlanDef(id) {
   // dummy function for getting the PlanDefinition
   // which can contain information to inform
   // the app what to do when notified
@@ -39,7 +39,7 @@ function getPlanDef(id, res) {
   if (resultList[0]) {
     return resultList[0];
   } else {
-      return null;
+    return null;
   }
 }
 

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -1,0 +1,61 @@
+const { StatusCodes } = require('http-status-codes');
+
+const express = require('express');
+const router = express.Router();
+
+// POST /
+// Recieve subscription notification
+router.post('/:id', (req, res) => {
+    const id = req.params.id;
+    res.sendStatus(StatusCodes.OK);
+    const subscription = getSubscription(id);
+    useSubscription(subscription);
+  });
+
+router.put('/:id/:resource/:resourceId', (req, res) => {
+    const id = req.params.id;
+    res.sendStatus(StatusCodes.OK);
+    const subscription = getSubscription(id);
+    useSubscription(subscription, req.body);
+    
+});
+function getSubscription(id) {
+    // dummy function for getting the subscription
+    // which can contain information to inform
+    // the app what to do when notified
+    return {
+        subscriptionResource: 
+          {
+            'resourceType': 'Subscription',
+            'criteria': 'Patient?_id=1',
+            'channel': {
+            'type': 'rest-hook',
+            'endpoint': 'http://example.com/subscription/1234',
+            'header': ['content-type: application/fhir+json']
+            }
+          }
+        action: 'name'
+      };
+}
+function useSubscription(subscription, resource = null) {
+    // trigger criteria
+    const subscriptionResource = subscription.subscriptionResource;
+    const criteria = subscriptionResource.criteria;
+    if (subscriptionResource.channel.type === 'rest-hook') {
+        const header = {};
+        subscriptionResource.channel.header.forEach((element) => {
+            const pair = element.split(':');
+            header[pair[0]] = pair[1];
+        });
+
+        if (resource) {
+            // TODO
+        }
+    }
+
+    // TODO: Make the client do something based on the action/resource/criteria
+    const action = subscription.action;
+
+}
+
+module.exports = router;

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -6,56 +6,54 @@ const router = express.Router();
 // POST /
 // Recieve subscription notification
 router.post('/:id', (req, res) => {
-    const id = req.params.id;
-    res.sendStatus(StatusCodes.OK);
-    const subscription = getSubscription(id);
-    useSubscription(subscription);
-  });
+  const id = req.params.id;
+  res.sendStatus(StatusCodes.OK);
+  const subscription = getSubscription(id);
+  useSubscription(subscription);
+});
 
 router.put('/:id/:resource/:resourceId', (req, res) => {
-    const id = req.params.id;
-    res.sendStatus(StatusCodes.OK);
-    const subscription = getSubscription(id);
-    useSubscription(subscription, req.body);
-    
+  const id = req.params.id;
+  res.sendStatus(StatusCodes.OK);
+  const subscription = getSubscription(id);
+  useSubscription(subscription, req.body);
 });
 function getSubscription(id) {
-    // dummy function for getting the subscription
-    // which can contain information to inform
-    // the app what to do when notified
-    return {
-        subscriptionResource: 
-          {
-            'resourceType': 'Subscription',
-            'criteria': 'Patient?_id=1',
-            'channel': {
-            'type': 'rest-hook',
-            'endpoint': 'http://example.com/subscription/1234',
-            'header': ['content-type: application/fhir+json']
-            }
-          }
-        action: 'name'
-      };
+  // dummy function for getting the subscription
+  // which can contain information to inform
+  // the app what to do when notified
+  console.log(id);
+  return {
+    subscriptionResource: {
+      resourceType: 'Subscription',
+      criteria: 'Patient?_id=1',
+      channel: {
+        type: 'rest-hook',
+        endpoint: 'http://example.com/subscription/1234',
+        header: ['content-type: application/fhir+json']
+      }
+    },
+    action: 'name'
+  };
 }
 function useSubscription(subscription, resource = null) {
-    // trigger criteria
-    const subscriptionResource = subscription.subscriptionResource;
-    const criteria = subscriptionResource.criteria;
-    if (subscriptionResource.channel.type === 'rest-hook') {
-        const header = {};
-        subscriptionResource.channel.header.forEach((element) => {
-            const pair = element.split(':');
-            header[pair[0]] = pair[1];
-        });
+  // trigger criteria
+  const subscriptionResource = subscription.subscriptionResource;
+  // const criteria = subscriptionResource.criteria;
+  if (subscriptionResource.channel.type === 'rest-hook') {
+    const header = {};
+    subscriptionResource.channel.header.forEach(element => {
+      const pair = element.split(':');
+      header[pair[0]] = pair[1];
+    });
 
-        if (resource) {
-            // TODO
-        }
+    if (resource) {
+      // TODO
     }
+  }
 
-    // TODO: Make the client do something based on the action/resource/criteria
-    const action = subscription.action;
-
+  // TODO: Make the client do something based on the action/resource/criteria
+  // const action = subscription.action;
 }
 
 module.exports = router;

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -2,33 +2,41 @@ const { StatusCodes } = require('http-status-codes');
 
 const express = require('express');
 const router = express.Router();
+const db = require('../storage/DataAccess');
+const COLLECTION = 'plandefs';
 
 // POST /
 // Recieve subscription notification
 router.post('/:id', (req, res) => {
   const id = req.params.id;
-  res.sendStatus(StatusCodes.OK);
-  const planDef = getPlanDef(id);
-  usePlanDef(planDef);
+  const planDef = getPlanDef(id.res);
+  if (planDef) {
+    res.sendStatus(StatusCodes.OK);
+    usePlanDef(planDef);
+  }
 });
 
 // if the subscription returns a resource, the notification
 // will be a PUT instead of a POST
 router.put('/:id/:resource/:resourceId', (req, res) => {
   const id = req.params.id;
-  res.sendStatus(StatusCodes.OK);
-  const planDef = getPlanDef(id);
-  usePlanDef(planDef, req.body);
+  const planDef = getPlanDef(id, res);
+  if (planDef) {
+    res.sendStatus(StatusCodes.OK);
+    usePlanDef(planDef, req.body);
+  }
 });
 
-function getPlanDef(id) {
+function getPlanDef(id, res) {
   // dummy function for getting the PlanDefinition
   // which can contain information to inform
   // the app what to do when notified
-  return {
-    resourceType: 'PlanDefinition',
-    id: id
-  };
+  const resultList = db.select(COLLECTION, s => s.id === id);
+  if (resultList[0]) {
+    return resultList[0];
+  } else {
+    res.sendStatus(StatusCodes.NOT_FOUND); // 404
+  }
 }
 
 function getSubscription(id) {


### PR DESCRIPTION
This adds a subscription endpoint at `/notif`.  You can test this by setting up the medmorph-ehr, posting the following subscription resource, posting any patient resource, and then modifying that patient resource with a PUT.

```{
  "resourceType": "Subscription",
  "id": "1",
  "status": "active",
  "criteria": "Patient?_id=1",
  "channel": {
    "type": "rest-hook",
    "endpoint": "http://**your-ip-here**:3000/notif/1234",
    "payload": "application/fhir+json"
  }
}
```

To run this locally, if you're using docker, the medmorph-ehr will fail to find the locally ran version of the backend, so I referred to it by IP in testing.

This method will make a PUT request to the backend with the body populated with the fhir resource named in the criteria. If the `payload` parameter is replaced with `header` (or removed) the notification will be a POST instead, and it will be empty. 

There are a couple TODO's in the code, since the task was simply to accept the incoming subscription notification.  In the example subscription, the notification comes with a FHIR resource that we can look at.  With the empty POST, we'd have to go retrieve the resource ourselves if we want to.

If we want to have different subscriptions set up to do different things, we need to store the subscriptions in the database, along with a separate `ID` or action `name` to tell the app what to do based on the subscriptions ID, which in this case is `1234`.  While this could serve as a unique ID itself, I opted to have the app get the subscription resource itself (however it may do that) along with some arbitrary `action` string.

The workflow could potentially be that the subscription notification comes in, and according to the `id`, or the `1234` part of the URL which is decided when we make the subscription, the backend runs some specific function.

I think this is simpler, but avoids the database, and may not be as robust.  We wouldn't need to fetch the subscription from the FHIR server, or keep a copy in our database, we could simply point the subscription endpoint at  `http://localhost:3000/notif/lookup` and simply have `lookup` tied to some function in the backend, and when the notification comes to the endpoint, we'd know which action to do.  This could be done by having a large `switch` statement that passes along the notification to the relevant function.



