### PR TITLE
Turn KnowldegeArtifacts into Subscriptions

### DIFF
--- a/src/utils/__tests__/fhir.test.js
+++ b/src/utils/__tests__/fhir.test.js
@@ -1,0 +1,62 @@
+const { subscriptionsFromPlanDef, subscriptionsFromBundle } = require('../fhir');
+
+describe('Test creating Subscriptions', () => {
+  test('It creates correct Subscription', () => {
+    const planDef = {
+      resourceType: 'PlanDefinition',
+      action: [
+        {
+          trigger: [
+            {
+              extension: [
+                {
+                  url:
+                    'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
+                  valueCodeableConcept: {
+                    coding: [
+                      {
+                        system:
+                          'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
+                        code: 'encounter-change'
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              extension: [
+                {
+                  url:
+                    'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
+                  valueCodeableConcept: {
+                    coding: [
+                      {
+                        system:
+                          'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
+                        code: 'new-labresult'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    const bundle = {
+      entry: [
+        {
+          resource: planDef
+        },
+        {
+          resource: planDef
+        }
+      ]
+    };
+    console.log(subscriptionsFromPlanDef(planDef));
+    console.log(subscriptionsFromBundle(bundle).length);
+    expect(true).toBeTruthy();
+  });
+});

--- a/src/utils/__tests__/fhir.test.js
+++ b/src/utils/__tests__/fhir.test.js
@@ -60,4 +60,27 @@ describe('Test creating Subscriptions', () => {
     expect(subscription.channel.endpoint).toBe(TEST_URL);
     expect(subscription.channel.header[0]).toBe(`Authorization: Bearer ${TEST_TOKEN}`);
   });
+
+  test('It does not include undefined in the list when a Subscription could not be created', () => {
+    const trigger = {
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
+          valueCodeableConcept: {
+            coding: [
+              {
+                system:
+                  'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
+                code: 'mannual-notification'
+              }
+            ]
+          }
+        }
+      ]
+    };
+    planDef.action[0].trigger.push(trigger);
+    const subscriptions = subscriptionsFromPlanDef(planDef, TEST_URL, TEST_TOKEN);
+    expect(subscriptions.length).toBe(1);
+    expect(subscriptions).not.toContain(undefined);
+  });
 });

--- a/src/utils/__tests__/fhir.test.js
+++ b/src/utils/__tests__/fhir.test.js
@@ -1,52 +1,43 @@
 const { subscriptionsFromPlanDef, subscriptionsFromBundle } = require('../fhir');
 
 describe('Test creating Subscriptions', () => {
-  test('It creates correct Subscription', () => {
-    const planDef = {
-      resourceType: 'PlanDefinition',
-      action: [
-        {
-          trigger: [
-            {
-              extension: [
-                {
-                  url:
-                    'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
-                  valueCodeableConcept: {
-                    coding: [
-                      {
-                        system:
-                          'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
-                        code: 'encounter-change'
-                      }
-                    ]
-                  }
+  const TEST_URL = 'http://example.org';
+  const TEST_TOKEN = 'test';
+  const planDef = {
+    resourceType: 'PlanDefinition',
+    action: [
+      {
+        trigger: [
+          {
+            extension: [
+              {
+                url: 'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
+                valueCodeableConcept: {
+                  coding: [
+                    {
+                      system:
+                        'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
+                      code: 'medication-change'
+                    }
+                  ]
                 }
-              ]
-            },
-            {
-              extension: [
-                {
-                  url:
-                    'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType',
-                  valueCodeableConcept: {
-                    coding: [
-                      {
-                        system:
-                          'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents',
-                        code: 'new-labresult'
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    };
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  test('It converts a bundle into subscriptions', () => {
     const bundle = {
       entry: [
+        {
+          resource: planDef
+        },
+        {
+          resource: planDef
+        },
         {
           resource: planDef
         },
@@ -55,8 +46,18 @@ describe('Test creating Subscriptions', () => {
         }
       ]
     };
-    console.log(subscriptionsFromPlanDef(planDef));
-    console.log(subscriptionsFromBundle(bundle).length);
-    expect(true).toBeTruthy();
+    const bundleSubscriptions = subscriptionsFromBundle(bundle, TEST_URL, TEST_TOKEN);
+    expect(bundleSubscriptions.length).toBe(4);
+  });
+
+  test('It converts medication-change correctly', () => {
+    const subscriptions = subscriptionsFromPlanDef(planDef, TEST_URL, TEST_TOKEN);
+    expect(subscriptions.length).toBe(1);
+
+    const subscription = subscriptions[0];
+    expect(subscription.criteria).toBe('MedicationRequest');
+    expect(subscription._criteria.length).toBe(3);
+    expect(subscription.channel.endpoint).toBe(TEST_URL);
+    expect(subscription.channel.header[0]).toBe(`Authorization: Bearer ${TEST_TOKEN}`);
   });
 });

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -164,15 +164,27 @@ function subscriptionsFromPlanDef(planDef, url, token) {
 
   if (action.trigger?.length === 0) return [];
 
-  return action.trigger.map(trigger => {
+  return action.trigger.reduce((subscriptions, trigger) => {
     const namedEventExt = trigger.extension.find(e => e.url === NAMED_EVENT_EXTENSION);
     const namedEventCoding = namedEventExt.valueCodeableConcept.coding.find(
       c => c.system === NAMED_EVENT_CODE_SYSTEM
     );
 
     const criteria = namedEventToCriteria(namedEventCoding.code);
-    if (criteria) return generateSubscription(namedEventCoding.code, criteria, url, token);
-  });
+    if (criteria)
+      subscriptions.push(generateSubscription(namedEventCoding.code, criteria, url, token));
+    return subscriptions;
+  }, []);
+
+  // return action.trigger.map(trigger => {
+  //   const namedEventExt = trigger.extension.find(e => e.url === NAMED_EVENT_EXTENSION);
+  //   const namedEventCoding = namedEventExt.valueCodeableConcept.coding.find(
+  //     c => c.system === NAMED_EVENT_CODE_SYSTEM
+  //   );
+
+  //   const criteria = namedEventToCriteria(namedEventCoding.code);
+  //   if (criteria) return generateSubscription(namedEventCoding.code, criteria, url, token);
+  // });
 }
 
 /**

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -5,6 +5,14 @@ const NAMED_EVENT_EXTENSION =
   'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType';
 const NAMED_EVENT_CODE_SYSTEM =
   'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents';
+const BACKPORT_SUBSCRIPTION_PROFILE =
+  'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-subscription';
+const BACKPORT_TOPIC_EXTENSION =
+  'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-topic-canonical';
+const BACKPORT_PAYLOAD_EXTENSION =
+  'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content';
+const BACKPORT_ADDITIONAL_CRITERIA_EXTENSION =
+  'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-additional-criteria';
 
 /**
  * Helper method to create an OperationOutcome fwith a message
@@ -64,6 +72,66 @@ function refreshKnowledgeArtifacts(db) {
     });
   });
 }
+/**
+ * Helper method to create a Subscription resource
+ *
+ * @param {string} code - named event code
+ * @param {string} criteria - the criteria for the named event code
+ * @param {string} url - the notification endpoint url
+ * @param {string} token - access token for header
+ * @returns a R5 Backport Subscription
+ */
+function generateSubscription(code, criteria, url, token) {
+  const subscription = {
+    resourceType: 'Subscription',
+    meta: {
+      profile: [BACKPORT_SUBSCRIPTION_PROFILE]
+    },
+    extension: [
+      {
+        url: BACKPORT_TOPIC_EXTENSION,
+        valueUri: `http://example.org/medmorph/subscriptiontopic/${code}`
+      }
+    ],
+    criteria: `${criteria}`,
+    channel: {
+      type: 'rest-hook',
+      endpoint: url,
+      payload: 'application/fhir+json',
+      _payload: {
+        extension: [
+          {
+            url: BACKPORT_PAYLOAD_EXTENSION,
+            valueCode: 'full-resource'
+          }
+        ]
+      },
+      header: [`Authorization: Bearer ${token}`]
+    }
+  };
+
+  // Fix the criteria for Medication by adding all criteria
+  if (criteria === 'Medication') {
+    // Multiple criteria indicates logical OR
+    subscription.criteria = 'MedicationRequest';
+    subscription._criteria = [
+      {
+        url: BACKPORT_ADDITIONAL_CRITERIA_EXTENSION,
+        valueString: 'MedicationDispense'
+      },
+      {
+        url: BACKPORT_ADDITIONAL_CRITERIA_EXTENSION,
+        valueString: 'MedicationStatement'
+      },
+      {
+        url: BACKPORT_ADDITIONAL_CRITERIA_EXTENSION,
+        valueString: 'MedicationAdministration'
+      }
+    ];
+  }
+
+  return subscription;
+}
 
 /**
  * Take a Knowledge Artifact Bundle and generate Subscription resources for the named events
@@ -101,44 +169,56 @@ function subscriptionsFromPlanDef(planDef, url, token) {
       c => c.system === NAMED_EVENT_CODE_SYSTEM
     );
 
-    return {
-      resourceType: 'Subscription',
-      criteria: `${namedEventToCriteria(namedEventCoding.code)}`,
-      channel: {
-        type: 'rest-hook',
-        endpoint: url,
-        payload: 'application/fhir+json',
-        header: `Authorization: Bearer ${token}`
-      }
-    };
+    const criteria = namedEventToCriteria(namedEventCoding.code);
+    if (criteria) return generateSubscription(namedEventCoding.code, criteria, url, token);
   });
 }
 
 /**
- * Take a named event code and generate the Subscription.criteria string
+ * Take a named event code and generate the Subscription.criteria string. This will
+ * not always be a FHIR resource. Since the medication codes map to multiple resources
+ * only 'Medication' is returned and then all the resources are added to the criteria
+ * when the Subscription resource is created.
+ *
+ * When a Subscription is not applicable (i.e. manual-notification) then null is returned.
  *
  * @param {string} code - the named event code
- * @returns the Subscription.criteria string
+ * @returns the Subscription.criteria string or null if Subscription is not applicable
  */
 function namedEventToCriteria(code) {
   const parts = code.split('-');
 
   let resource;
   if (parts[0] === 'new' || parts[0] === 'modified') resource = parts[1];
-  else if (parts[1] === 'change') resource = parts[0];
-  else console.log(code);
-  console.log(resource);
+  else if (parts[1] === 'change' || parts[1] === 'start' || parts[1] === 'close')
+    resource = parts[0];
+  else return null;
 
-  // TODO: implement this
-
-  return resource === undefined ? code : resource;
+  switch (resource) {
+    case 'encounter':
+      return 'Encounter';
+    case 'diagnosis':
+      return 'Condition';
+    case 'medication':
+      return 'Medication';
+    case 'labresult':
+      return 'Observation?category=laboratory';
+    case 'order':
+      return 'ServiceRequest';
+    case 'procedure':
+      return 'Procedure';
+    case 'immunization':
+      return 'Immunization';
+    case 'demographic':
+      return 'Patient';
+    default:
+      return null;
+  }
 }
 
-// TODO: remove namedEventToCriteria from export
 module.exports = {
   generateOperationOutcome,
   refreshKnowledgeArtifacts,
   subscriptionsFromBundle,
-  subscriptionsFromPlanDef,
-  namedEventToCriteria
+  subscriptionsFromPlanDef
 };

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -1,6 +1,11 @@
 const axios = require('axios');
 const debug = require('debug')('medmorph-backend:server');
 
+const NAMED_EVENT_EXTENSION =
+  'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType';
+const NAMED_EVENT_CODE_SYSTEM =
+  'http://hl7.org/fhir/us/medmorph/CodeSystem/us-ph-triggerdefinition-namedevents';
+
 /**
  * Helper method to create an OperationOutcome fwith a message
  *
@@ -60,4 +65,80 @@ function refreshKnowledgeArtifacts(db) {
   });
 }
 
-module.exports = { generateOperationOutcome, refreshKnowledgeArtifacts };
+/**
+ * Take a Knowledge Artifact Bundle and generate Subscription resources for the named events
+ *
+ * @param {Bundle} specBundle - KA Bundle with PlanDefinition
+ * @param {string} url - the notification endpoint url
+ * @param {string} token - the authorization token for the Subscription notification
+ * @returns list of Subscription resources
+ */
+function subscriptionsFromBundle(specBundle, url, token) {
+  const planDefs = specBundle.entry.filter(e => e.resource.resourceType === 'PlanDefinition');
+  if (!planDefs.length) {
+    throw new Error('Specification Bundle does not contain a PlanDefinition');
+  }
+
+  return planDefs.map(planDef => subscriptionsFromPlanDef(planDef.resource, url, token)).flat();
+}
+
+/**
+ * Take a single PlanDefinition and generate a Subscription resource for the named events
+ *
+ * @param {PlanDefinition} planDef - KA PlanDefinition
+ * @param {string} url - the notification endpoint url
+ * @param {string} token - the authorization token for the Subscription notification
+ * @returns list of Subscription resources (one for each trigger on the first action).
+ */
+function subscriptionsFromPlanDef(planDef, url, token) {
+  const action = planDef.action[0];
+
+  if (action.trigger?.length === 0) return [];
+
+  return action.trigger.map(trigger => {
+    const namedEventExt = trigger.extension.find(e => e.url === NAMED_EVENT_EXTENSION);
+    const namedEventCoding = namedEventExt.valueCodeableConcept.coding.find(
+      c => c.system === NAMED_EVENT_CODE_SYSTEM
+    );
+
+    return {
+      resourceType: 'Subscription',
+      criteria: `${namedEventToCriteria(namedEventCoding.code)}`,
+      channel: {
+        type: 'rest-hook',
+        endpoint: url,
+        payload: 'application/fhir+json',
+        header: `Authorization: Bearer ${token}`
+      }
+    };
+  });
+}
+
+/**
+ * Take a named event code and generate the Subscription.criteria string
+ *
+ * @param {string} code - the named event code
+ * @returns the Subscription.criteria string
+ */
+function namedEventToCriteria(code) {
+  const parts = code.split('-');
+
+  let resource;
+  if (parts[0] === 'new' || parts[0] === 'modified') resource = parts[1];
+  else if (parts[1] === 'change') resource = parts[0];
+  else console.log(code);
+  console.log(resource);
+
+  // TODO: implement this
+
+  return resource === undefined ? code : resource;
+}
+
+// TODO: remove namedEventToCriteria from export
+module.exports = {
+  generateOperationOutcome,
+  refreshKnowledgeArtifacts,
+  subscriptionsFromBundle,
+  subscriptionsFromPlanDef,
+  namedEventToCriteria
+};

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -55,24 +55,6 @@ function getResources(server, type, ids = null) {
 }
 
 /**
- * Get all knowledge artifacts (from servers registered in the config
- * file) and save them. Stores all refrenced resources as well.
- */
-function refreshKnowledgeArtifacts(db) {
-  const servers = db.select('servers', s => s.type === 'KA');
-  servers.forEach(server => {
-    getResources(server.endpoint, 'PlanDefinition').then(data => {
-      debug(`Fetched ${server.endpoint}/${data.resourceType}/${data.id}`);
-      if (data.entry?.length === 0) return;
-      const resources = data.entry.map(entry => entry.resource);
-      resources.forEach(resource => {
-        const collection = `${resource.resourceType.toLowerCase()}s`;
-        db.upsert(collection, resource, r => r.id === resource.id);
-      });
-    });
-  });
-}
-/**
  * Helper method to create a Subscription resource
  *
  * @param {string} code - named event code
@@ -131,6 +113,25 @@ function generateSubscription(code, criteria, url, token) {
   }
 
   return subscription;
+}
+
+/**
+ * Get all knowledge artifacts (from servers registered in the config
+ * file) and save them. Stores all refrenced resources as well.
+ */
+function refreshKnowledgeArtifacts(db) {
+  const servers = db.select('servers', s => s.type === 'KA');
+  servers.forEach(server => {
+    getResources(server.endpoint, 'PlanDefinition').then(data => {
+      debug(`Fetched ${server.endpoint}/${data.resourceType}/${data.id}`);
+      if (data.entry?.length === 0) return;
+      const resources = data.entry.map(entry => entry.resource);
+      resources.forEach(resource => {
+        const collection = `${resource.resourceType.toLowerCase()}s`;
+        db.upsert(collection, resource, r => r.id === resource.id);
+      });
+    });
+  });
 }
 
 /**

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -175,16 +175,6 @@ function subscriptionsFromPlanDef(planDef, url, token) {
       subscriptions.push(generateSubscription(namedEventCoding.code, criteria, url, token));
     return subscriptions;
   }, []);
-
-  // return action.trigger.map(trigger => {
-  //   const namedEventExt = trigger.extension.find(e => e.url === NAMED_EVENT_EXTENSION);
-  //   const namedEventCoding = namedEventExt.valueCodeableConcept.coding.find(
-  //     c => c.system === NAMED_EVENT_CODE_SYSTEM
-  //   );
-
-  //   const criteria = namedEventToCriteria(namedEventCoding.code);
-  //   if (criteria) return generateSubscription(namedEventCoding.code, criteria, url, token);
-  // });
 }
 
 /**


### PR DESCRIPTION
Util functions to convert a KA Bundle or a single PlanDefinition into the necessary Subscriptions. This uses the R5 Backport for Subscriptions. Since `SubscriptionTopic`s don't exist in R4 the topic is defined via the canonical url and then it is up to the implementing server to know what those map to. 