### PR TITLE
Add GET /jwks for Public JWKS

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ const { StatusCodes } = require('http-status-codes');
 
 const db = require('../storage/DataAccess');
 const testService = require('../services/test_service');
+const publicKey = require('../keys/publicKey.json');
 const { refreshKnowledgeArtifacts } = require('../utils/fhir');
 
 router.get('/', testService);
@@ -11,6 +12,10 @@ router.get('/', testService);
 router.post('/fetch-ka', (req, res) => {
   refreshKnowledgeArtifacts(db);
   res.sendStatus(StatusCodes.OK);
+});
+
+router.get('/jwks', (req, res) => {
+  res.send(publicKey);
 });
 
 module.exports = router;


### PR DESCRIPTION
Adding the `/jwks` endpoint to host the public keys. When registering this server as a client this is the endpoint used for the jwks-url.

Updated the Endpoint wiki with the new endpoint: https://github.com/mcode/medmorph-backend/wiki/Endpoints