### PR TITLE
Make jwks url public

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ const KeycloakBearerStrategy = require('passport-keycloak-bearer');
 
 const fhirRouter = require('./routes/fhir');
 const indexRouter = require('./routes/index');
+const publicRouter = require('./routes/public');
 const serversRouter = require('./routes/servers');
 const wellKnownRouter = require('./routes/wellknown');
 const subscriptionsRouter = require('./routes/subscriptions');
@@ -35,6 +36,7 @@ passport.use(
 
 // Open Routes
 app.use('/.well-known', wellKnownRouter);
+app.use('/public', publicRouter);
 
 // Protected Routes
 app.use('/', backendAuthorization, indexRouter);

--- a/src/routes/public.js
+++ b/src/routes/public.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+
+const publicKey = require('../keys/publicKey.json');
+
+router.get('/jwks', (req, res) => {
+  res.send(publicKey);
+});
+
+module.exports = router;


### PR DESCRIPTION
Quick fix to make the JWKs url not require backend auth. Created a new /public route for endpoints which don't require authorization