### PR TITLE
Forward message response to EHR

### DIFF
--- a/src/services/messaging.js
+++ b/src/services/messaging.js
@@ -1,5 +1,6 @@
 const { StatusCodes } = require('http-status-codes');
-const { generateOperationOutcome } = require('../utils/fhir');
+const { generateOperationOutcome, forwardMessageResponse } = require('../utils/fhir');
+const debug = require('debug')('medmorph-backend:server');
 
 function processMessage(req, res) {
   // Validate the message bundle
@@ -36,7 +37,9 @@ function processMessage(req, res) {
     return;
   }
 
-  // TODO: do something with the message response
+  forwardMessageResponse(messageBundle).then(() =>
+    debug(`Response to /Bundle/${messageBundle.id} forwarded to EHR`)
+  );
 
   res.sendStatus(StatusCodes.OK);
 }

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -89,7 +89,7 @@ const baseIgActions = {
             context.flags['submitted'] = true;
             debug(`/Bundle/${context.reportingBundle.id} submitted to ${context.client.dest}`);
 
-            if (result.data) {
+            if (result.data?.resourceType === 'Bundle') {
               forwardMessageResponse(result.data).then(() =>
                 debug(`Response to /Bundle/${context.reportingBundle.id} forwarded to EHR`)
               );


### PR DESCRIPTION
Forward message response (either from an async post to $process-message or the sync response from submitting the bundle) to the EHR server.