### PR TITLE
Knowledge Artifact Subscriptions

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,7 @@ const wellKnownRouter = require('./routes/wellknown');
 const subscriptionsRouter = require('./routes/subscriptions');
 
 const { backendAuthorization, subscriptionAuthorization } = require('./utils/auth');
-const { refreshKnowledgeArtifacts } = require('./utils/fhir');
+const { refreshAllKnowledgeArtifacts, subscribeToKnowledgeArtifacts } = require('./utils/fhir');
 
 const app = express();
 app.use('/public', express.static(__dirname + '/../public'));
@@ -47,6 +47,9 @@ app.use('/fhir', backendAuthorization, fhirRouter);
 app.use('/servers', backendAuthorization, serversRouter);
 app.use('/notif', subscriptionAuthorization, subscriptionsRouter);
 
-setTimeout(() => refreshKnowledgeArtifacts(), 1000);
+setTimeout(() => {
+  refreshAllKnowledgeArtifacts();
+  subscribeToKnowledgeArtifacts();
+}, 1000);
 
 module.exports = app;

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -5,8 +5,6 @@ const express = require('express');
 const router = express.Router();
 const servers = require('../storage/servers');
 
-const db = require('../storage/DataAccess');
-
 // GET /
 // List all servers
 router.get('/', (req, res) => {
@@ -47,7 +45,7 @@ router.put('/:id', (req, res) => {
     return;
   }
 
-  db.addServer(req.body);
+  servers.addServer(req.body);
   res.sendStatus(StatusCodes.OK); // 200
 });
 

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -2,13 +2,66 @@ const { StatusCodes } = require('http-status-codes');
 
 const express = require('express');
 const router = express.Router();
+const axios = require('axios');
 const db = require('../storage/DataAccess');
 const { startReportingWorkflow } = require('../utils/reporting_workflow');
+const { getServerById } = require('../storage/servers');
+const { refreshKnowledgeArtifact, getEndpointId } = require('../utils/fhir');
+const { getAccessToken } = require('../utils/client');
+const debug = require('debug')('medmorph-backend:server');
 
 const COLLECTION = 'plandefinitions';
+const ENDPOINTS = 'endpoints';
 
-// POST /
-// Recieve subscription notification
+/**
+ * Notification from KA Repo to refresh artifacts. The id param is the
+ * server id from the database
+ */
+router.post('/ka/:id', (req, res) => {
+  const id = req.params.id;
+  const server = getServerById(id);
+  if (server) {
+    refreshKnowledgeArtifact(server);
+    res.sendStatus(StatusCodes.OK);
+  } else res.sendStatus(StatusCodes.NOT_FOUND);
+});
+
+/**
+ * Notification from KA Repo to refresh artifacts. The id param is the
+ * server id from the database and resourceId is the PlanDefinition id.
+ * The body contains the triggering PlanDefinition
+ */
+router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
+  const id = req.params.id;
+  const planDefinition = req.body;
+  const endpointId = getEndpointId(planDefinition);
+  const server = getServerById(id);
+
+  if (!server) {
+    res.sendStatus(StatusCodes.NOT_FOUND);
+    return;
+  }
+
+  db.upsert(COLLECTION, planDefinition, r => r.id === planDefinition.id);
+  debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
+
+  const token = await getAccessToken(server);
+  const headers = { Authorization: `Bearer ${token}` };
+  axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
+    if (response.data) {
+      const endpoint = response.data;
+      db.upsert(ENDPOINTS, endpoint, r => r.id === endpoint.id);
+      debug(`Fetched ${server.endpoint}/Endpoint/${endpoint.id}`);
+    }
+  });
+
+  res.sendStatus(StatusCodes.OK);
+});
+
+/**
+ * Notification from EHR of changed data to start workflow process. The
+ * id param is the PlanDefinition id which defines the workflow
+ */
 router.post('/:id', (req, res) => {
   const id = req.params.id;
   const planDef = getPlanDef(id);
@@ -20,8 +73,11 @@ router.post('/:id', (req, res) => {
   }
 });
 
-// if the subscription returns a resource, the notification
-// will be a PUT instead of a POST
+/**
+ * Notification from EHR of changed data to start workflow process. The
+ * id param is the PlanDefinition if which defines the workflow. The body
+ * contains the triggering resource.
+ */
 router.put('/:id/:resource/:resourceId', (req, res) => {
   const id = req.params.id;
   const planDef = getPlanDef(id);

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -45,7 +45,7 @@ router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
   db.upsert(COLLECTION, planDefinition, r => r.id === planDefinition.id);
   debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
 
-  const token = await getAccessToken(server);
+  const token = await getAccessToken(server.endpoint);
   const headers = { Authorization: `Bearer ${token}` };
   axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
     if (response.data) {

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -75,11 +75,11 @@ async function getResources(server, resourceType) {
  * @param {string} criteria - the criteria for the named event code
  * @param {string} url - the notification endpoint url
  * @param {string} token - access token for header
- * @param {string} subscriptionTopic - R5 backport subscription topic
  * @param {string} id - the id to assign the Subscription
+ * @param {string} subscriptionTopic - R5 backport subscription topic
  * @returns a R5 Backport Subscription
  */
-function generateSubscription(criteria, url, token, subscriptionTopic = undefined, id = undefined) {
+function generateSubscription(criteria, url, token, id = undefined, subscriptionTopic = undefined) {
   const subscription = {
     id: id ?? `sub${uuidv4()}`,
     resourceType: 'Subscription',
@@ -173,7 +173,7 @@ function subscribeToKnowledgeArtifacts() {
     const token = await getAccessToken(server.endpoint);
     const headers = { Authorization: `Bearer ${token}` };
     axios
-      .put(`${server.endpoint}/Subscription/id`, subscription, { headers: headers })
+      .put(`${server.endpoint}/Subscription/${id}`, subscription, { headers: headers })
       .then(() => debug(`Subscription created for KA from ${server.name}`));
   });
 }

--- a/src/utils/reporting_workflow.js
+++ b/src/utils/reporting_workflow.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require('uuid');
 const graphlib = require('graphlib');
 const db = require('../storage/DataAccess');
-const { getReferencedResource } = require('../utils/fhir');
+const { getReferencedResource, getEndpointId } = require('../utils/fhir');
 const { getEHRServer } = require('../storage/servers');
 const { baseIgActions } = require('./actions');
 const debug = require('debug')('medmorph-backend:server');
@@ -36,8 +36,6 @@ https://github.com/mcode/medmorph-backend/wiki/Reporting-Workflow
 
 const BASE_REPORTING_BUNDLE_PROFILE =
   'http://hl7.org/fhir/us/medmorph/StructureDefinition/us-ph-reporting-bundle';
-const RECEIVER_ADDRESS_EXT =
-  'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-receiverAddress';
 
 /**
  * IG_REGISTRY maps the profile for a reporting bundle under an IG
@@ -76,9 +74,7 @@ async function startReportingWorkflow(planDef, resource = null) {
   else if (resource.resourceType === 'Encounter') encounter = resource;
 
   // Get the endpoint to submit the report to from the PlanDefinition
-  const receiverAddress = planDef.extension.find(e => e.url === RECEIVER_ADDRESS_EXT);
-  const endpointRef = receiverAddress.valueReference.reference;
-  const endpointId = endpointRef.split('/')[1];
+  const endpointId = getEndpointId(planDef);
   const endpoint = db.select('endpoints', e => e.id === endpointId);
   const destEndpoint = endpoint[0].address;
 


### PR DESCRIPTION
On startup subscribe to PlanDefinition on all KA repos. Implement the subscription notification endpoints to store the updated artifacts on change.

HAPI won't let me subscribe to criteria `PlanDefinition` so I opted for `PlanDefinition?_lastUpdated=gt2021-01-01`. If anyone knows a better way to subscribe to all PlanDefinitions without requiring the R5 backport topics let me know.