### PR TITLE
Subscription setup

### DIFF
--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -153,6 +153,7 @@ function refreshAllKnowledgeArtifacts() {
 
 /**
  * Get knowledge artifacts from a specific server.
+ * Generate Subscription resources from the KA Bundle with PlanDefinition
  *
  * @param {*} server - the server to refresh artifacts from
  */
@@ -188,6 +189,7 @@ function subscribeToKnowledgeArtifacts() {
 
 /**
  * Take a Knowledge Artifact Bundle and generate Subscription resources for the named events
+ * Saves Subscription resources to DB and posts them to EHR server
  *
  * @param {Bundle} specBundle - KA Bundle with PlanDefinition
  * @param {string} url - the notification endpoint url

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -213,11 +213,13 @@ function subscriptionsFromBundle(specBundle, url, token) {
 
     // Create/Update Subscriptions on EHR server
     const ehrServer = getEHRServer();
-    const ehrToken = await getAccessToken(ehrServer.endpoint);
-    const headers = { Authorization: `Bearer ${ehrToken}` };
-    axios
-      .put(`${ehrServer.endpoint}/Subscription/${subscriptionId}`, subscription, { headers })
-      .then(() => debug(`Subscription with id ${subscriptionId} created/updated on EHR server`));
+    if (ehrServer) {
+      const ehrToken = await getAccessToken(ehrServer.endpoint);
+      const headers = { Authorization: `Bearer ${ehrToken}` };
+      axios
+        .put(`${ehrServer.endpoint}/Subscription/${subscriptionId}`, subscription, { headers })
+        .then(() => debug(`Subscription with id ${subscriptionId} created/updated on EHR server`));
+    }
   });
 
   return subscriptions;

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -208,7 +208,7 @@ function subscriptionsFromBundle(specBundle, url, token) {
     const subscriptionId = subscription.id;
 
     // Store subscriptions in database
-    debug(`  ...Subscription/${subscriptionId}`);
+    debug(`Saved Subscription/${subscriptionId}`);
     db.upsert('subscriptions', subscription, s => s.id === subscriptionId);
 
     // Create/Update Subscriptions on EHR server

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -84,11 +84,11 @@ async function getResources(server, resourceType) {
  */
 function generateSubscription(criteria, url, token, id = undefined, subscriptionTopic = undefined) {
   // Add regex to check if criteria has at least one search param since HAPI is expecting this
-  const criteriaReg = /(.+)(\?.)+/;
+  const criteriaReg = /(.+)(\?)+/;
   const subscription = {
     id: id ?? `sub${uuidv4()}`,
     resourceType: 'Subscription',
-    criteria: criteriaReg.test(criteria) ? `${criteria}` : `${criteria}?_lastUpdated=gt2021-01-01`,
+    criteria: criteriaReg.test(criteria) ? `${criteria}` : `${criteria}?`,
     status: 'requested',
     channel: {
       type: 'rest-hook',

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -1,9 +1,9 @@
 const axios = require('axios');
-const { v4: uuidv4 } = require('uuid');
-const { getAccessToken } = require('./client');
 const debug = require('debug')('medmorph-backend:server');
 const db = require('../storage/DataAccess');
+const { getAccessToken } = require('./client');
 const { getEHRServer } = require('../storage/servers');
+const { v4: uuidv4 } = require('uuid');
 
 const NAMED_EVENT_EXTENSION =
   'http://hl7.org/fhir/us/medmorph/StructureDefinition/ext-us-ph-namedEventType';


### PR DESCRIPTION
Currently this is branched off of Ben's PR #19 to incorporate the subscription changes there.
When the PlanDefinitions from KA are refreshed, subscriptions are saved to the database and created on the EHR server.

- Call `subscriptionsFromBundle` whenever PlanDefinitions are refreshed.
- Added an id to subscription resources that is `${planDef.id}${namedEventCoding.code}` so that they can be updated in the database.
    - Using `axios.put` so that the EHR server uses this `id` so it will know when to create/update.
- Added a regex in `generateSubscription` to check if `criteria` has at least one search param since HAPI is expecting this(mentioned in #19).
    - If `criteria` doesn't have a search param, I add `?_lastUpdated=gt2021-01-01` to it so we can post to EHR server. If we come to a different solution in #19 I'll change it here also. 
