### PR TITLE
add logs to db

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -5,7 +5,7 @@
  */
 
 const app = require('../src/app');
-const debug = require('debug')('medmorph-backend:server');
+const debug = require('../src/storage/logs').debug('medmorph-backend:server');
 const http = require('http');
 
 /**

--- a/src/app.js
+++ b/src/app.js
@@ -24,8 +24,8 @@ app.use(logger('dev'));
 app.use(express.json());
 app.use(bodyParser.json({ type: ['application/json', 'application/fhir+json'] }));
 app.use(function(req, res, next) {
-    storeRequest(req);
-    next();
+  storeRequest(req);
+  next();
 });
 
 app.use(passport.initialize());

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const publicRouter = require('./routes/public');
 const serversRouter = require('./routes/servers');
 const wellKnownRouter = require('./routes/wellknown');
 const subscriptionsRouter = require('./routes/subscriptions');
+const { storeRequest } = require('./storage/logs');
 
 const { backendAuthorization, subscriptionAuthorization } = require('./utils/auth');
 const { refreshAllKnowledgeArtifacts, subscribeToKnowledgeArtifacts } = require('./utils/fhir');
@@ -22,6 +23,11 @@ app.use('/public', express.static(__dirname + '/../public'));
 app.use(logger('dev'));
 app.use(express.json());
 app.use(bodyParser.json({ type: ['application/json', 'application/fhir+json'] }));
+app.use(function(req, res, next) {
+    storeRequest(req);
+    next();
+});
+
 app.use(passport.initialize());
 
 passport.use(

--- a/src/routes/servers.js
+++ b/src/routes/servers.js
@@ -1,5 +1,5 @@
 const { StatusCodes } = require('http-status-codes');
-
+const error = require('../storage/logs').error('medmorph-backend:servers');
 const express = require('express');
 const router = express.Router();
 const servers = require('../storage/servers');
@@ -27,6 +27,7 @@ router.get('/:id', (req, res) => {
   if (resultList[0]) {
     res.send(resultList[0]);
   } else {
+    error(`Failed to find server with ID ${id} in database`);
     res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
 });

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -90,9 +90,9 @@ router.put('/:id/:resource/:resourceId', (req, res) => {
   const planDef = getPlanDef(id);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
-    debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${id}`)
+    debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${id}`);
     const collection = `${req.body.resourceType.toLowerCase()}s`;
-    db.upsert(collection, resource, r => r.id === resource.id);
+    db.upsert(collection, req.body, r => r.id === req.body.id);
     startReportingWorkflow(planDef, req.body);
   } else {
     res.sendStatus(StatusCodes.NOT_FOUND); // 404

--- a/src/services/messaging.js
+++ b/src/services/messaging.js
@@ -51,6 +51,7 @@ function processMessage(req, res) {
 
 function sendOperationOutcome(res, code, msg) {
   const operationOutcome = generateOperationOutcome(code, msg);
+  debug(`Message rejected with code ${code} and message ${msg}`);
   res
     .status(StatusCodes.BAD_REQUEST)
     .header('Content-Type', 'application/json')

--- a/src/storage/collections.js
+++ b/src/storage/collections.js
@@ -4,5 +4,9 @@ module.exports = {
   SUBSCRIPTIONS: 'subscriptions',
   ENDPOINTS: 'endpoints',
   COMPLETED_REPORTS: 'completedreports',
-  REPORTING: 'reporting'
+  REPORTING: 'reporting',
+  LOGS: 'logs',
+  ERRORS: 'errors',
+  MESSAGES: 'messages',
+  REQUESTS: 'requests'
 };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -32,17 +32,13 @@ function error(location) {
 }
 
 function storeRequest(request) {
-    const log = {
-        id: uuidv4(),
-        timestamp: Date.now(),
-        url: request.url,
-        body: request.body
-    }
-    db.insert(REQUESTS, log);
-}
-
-function getLogs() {
-  return db.select(LOGS, () => true);
+  const log = {
+    id: uuidv4(),
+    timestamp: Date.now(),
+    url: request.url,
+    body: request.body
+  };
+  db.insert(REQUESTS, log);
 }
 
 module.exports = { debug, error, storeRequest };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -1,0 +1,48 @@
+const db = require('./DataAccess');
+const { LOGS, ERRORS, REQUESTS } = require('./collections');
+const debugConsole = require('debug');
+const { v4: uuidv4 } = require('uuid');
+
+function debug(location) {
+  return message => {
+    const logger = debugConsole(location);
+    logger(message);
+    const log = {
+      id: uuidv4(),
+      timestamp: Date.now(),
+      message: message,
+      location: location
+    };
+    db.insert(LOGS, log);
+  };
+}
+
+function error(location) {
+  return error => {
+    const logger = debugConsole(location);
+    logger(error);
+    const log = {
+      id: uuidv4(),
+      timestamp: Date.now(),
+      error: error,
+      location: location
+    };
+    db.insert(ERRORS, log);
+  };
+}
+
+function storeRequest(request) {
+    const log = {
+        id: uuidv4(),
+        timestamp: Date.now(),
+        url: request.url,
+        body: request.body
+    }
+    db.insert(REQUESTS, log);
+}
+
+function getLogs() {
+  return db.select(LOGS, () => true);
+}
+
+module.exports = { debug, error, storeRequest };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -36,7 +36,8 @@ function storeRequest(request) {
     id: uuidv4(),
     timestamp: Date.now(),
     url: request.url,
-    body: request.body
+    body: request.body,
+    headers: request.headers
   };
   db.insert(REQUESTS, log);
 }

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -101,7 +101,7 @@ const baseIgActions = {
           context.flags['submitted'] = false;
         }
       )
-      .catch((err) => {
+      .catch(err => {
         error(err);
         context.flags['submitted'] = false;
       });
@@ -117,7 +117,7 @@ const baseIgActions = {
           context.flags['deidentified'] = false;
         }
       )
-      .catch((err) => {
+      .catch(err => {
         error(err);
         context.flags['deidentified'] = false;
       });
@@ -133,7 +133,7 @@ const baseIgActions = {
           context.flags['anonymized'] = false;
         }
       )
-      .catch((err) => {
+      .catch(err => {
         error(err);
         context.flags['anonymized'] = false;
       });
@@ -149,7 +149,7 @@ const baseIgActions = {
           context.flags['pseudonymized'] = false;
         }
       )
-      .catch((err) => {
+      .catch(err => {
         error(err);
         context.flags['pseudonymized'] = false;
       });

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -33,8 +33,8 @@ const { getAccessToken } = require('./client');
 const db = require('../storage/DataAccess');
 const { forwardMessageResponse } = require('./fhir');
 const { COMPLETED_REPORTS } = require('../storage/collections');
-const debug = require('debug')('medmorph-backend:server');
-
+const debug = require('../storage/logs').debug('medmorph-backend:actions');
+const error = require('../storage/logs').error('medmorph-backend:actions');
 const fhir = new Fhir();
 
 const baseIgActions = {
@@ -101,7 +101,8 @@ const baseIgActions = {
           context.flags['submitted'] = false;
         }
       )
-      .catch(() => {
+      .catch((err) => {
+        error(err);
         context.flags['submitted'] = false;
       });
   },
@@ -116,7 +117,8 @@ const baseIgActions = {
           context.flags['deidentified'] = false;
         }
       )
-      .catch(() => {
+      .catch((err) => {
+        error(err);
         context.flags['deidentified'] = false;
       });
   },
@@ -131,7 +133,8 @@ const baseIgActions = {
           context.flags['anonymized'] = false;
         }
       )
-      .catch(() => {
+      .catch((err) => {
+        error(err);
         context.flags['anonymized'] = false;
       });
   },
@@ -146,7 +149,8 @@ const baseIgActions = {
           context.flags['pseudonymized'] = false;
         }
       )
-      .catch(() => {
+      .catch((err) => {
+        error(err);
         context.flags['pseudonymized'] = false;
       });
   },
@@ -175,7 +179,13 @@ const baseIgActions = {
         }
 
         const getRecordsPromise = readFromEHR(uri).then(result => {
-          const resources = result.data.entry.map(e => e.resource);
+          debug(`/Bundle/${result.data.id} recieved from ${uri}`);
+          const resources = result.data.entry.map(e => {
+            const resource = e.resource;
+            const collection = `${resource.resourceType.toLowerCase()}s`;
+            db.upsert(collection, resource, r => r.id === resource.id);
+            return resource;
+          });
 
           const dateFilter = input.dateFilter;
           let filteredResources = [...resources];

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -4,6 +4,7 @@ const { v4 } = require('uuid');
 const queryString = require('query-string');
 const keys = require('../keys/privateKey.json');
 const servers = require('../storage/servers');
+const error = require('../storage/logs').error('medmorph-backend:client');
 
 /**
  * Generate and return access token for the specified server. If tokenEndpoint
@@ -38,7 +39,7 @@ async function connectToServer(url) {
   const data = await axios
     .post(tokenEndpoint, queryString.stringify(props), headers)
     .then(response => response.data)
-    .catch(err => console.error(err));
+    .catch(err => error(err));
   return data;
 }
 
@@ -59,7 +60,7 @@ async function getAccessToken(url) {
       return token.access_token;
     } catch (e) {
       servers.clearAccessToken(server);
-      console.error(e);
+      error(e);
       throw e;
     }
   } else {

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -254,7 +254,9 @@ function postSubscriptionsToEHR(subscriptions) {
       const headers = { Authorization: `Bearer ${ehrToken}` };
       axios
         .put(`${ehrServer.endpoint}/Subscription/${subscriptionId}`, subscription, { headers })
-        .then(() => debug(`Subscription with id ${subscriptionId} created/updated on ${ehrServer.endpoint}`));
+        .then(() =>
+          debug(`Subscription with id ${subscriptionId} created/updated on ${ehrServer.endpoint}`)
+        );
     }
   });
 }

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
 const { getAccessToken } = require('./client');
-const debug = require('debug')('medmorph-backend:server');
+const debug = require('../storage/logs').debug('medmorph-backend:fhir');
+const error = require('../storage/logs').error('medmorph-backend:fhir');
 const db = require('../storage/DataAccess');
 const { getEHRServer } = require('../storage/servers');
 const { generateToken } = require('./auth');
@@ -59,13 +60,13 @@ async function getResources(server, resourceType) {
   const axiosResponse = axios
     .get(url, { headers: headers })
     .then(response => response.data)
-    .catch(err => console.log(err));
+    .catch(err => error(err));
   return axiosResponse.then(data => {
     debug(`Fetched ${server}/${data.resourceType}/${data.id}`);
     if (!data.entry) return;
     const resources = data.entry.map(entry => entry.resource);
     resources.forEach(resource => {
-      debug(`  ...${resource.resourceType}/${resource.id}`);
+      debug(`Extracted ${resource.resourceType}/${resource.id} from bundle`);
       const collection = `${resource.resourceType.toLowerCase()}s`;
       db.upsert(collection, resource, r => r.id === resource.id);
     });
@@ -183,7 +184,7 @@ function subscribeToKnowledgeArtifacts() {
     const headers = { Authorization: `Bearer ${token}` };
     axios
       .put(`${server.endpoint}/Subscription/${id}`, subscription, { headers: headers })
-      .then(() => debug(`Subscription created for KA from ${server.name}`));
+      .then(() => debug(`Subscription created for KA from ${server.name} at ${server.endpoint}`));
   });
 }
 
@@ -253,7 +254,7 @@ function postSubscriptionsToEHR(subscriptions) {
       const headers = { Authorization: `Bearer ${ehrToken}` };
       axios
         .put(`${ehrServer.endpoint}/Subscription/${subscriptionId}`, subscription, { headers })
-        .then(() => debug(`Subscription with id ${subscriptionId} created/updated on EHR server`));
+        .then(() => debug(`Subscription with id ${subscriptionId} created/updated on ${ehrServer.endpoint}`));
     }
   });
 }
@@ -313,6 +314,9 @@ async function getReferencedResource(url, reference) {
     const token = await getAccessToken(url);
     const headers = { Authorization: `Bearer ${token}` };
     const resource = await axios.get(`${url}/${resourceType}/${id}`, { headers: headers });
+    debug(
+      `Retrieved reference resource ${resource.data.resourceType}/${resource.data.id} from ${url}`
+    );
     return resource.data;
   }
 

--- a/src/utils/reporting_workflow.js
+++ b/src/utils/reporting_workflow.js
@@ -5,7 +5,7 @@ const { getReferencedResource, getEndpointId } = require('../utils/fhir');
 const { getEHRServer } = require('../storage/servers');
 const { baseIgActions } = require('./actions');
 const { REPORTING, ENDPOINTS } = require('../storage/collections');
-const debug = require('debug')('medmorph-backend:server');
+const debug = require('../storage/logs').debug('medmorph-backend:reporting_workflow');
 
 /*
 


### PR DESCRIPTION
Adds a middleware for requests, puts resources into collections based on resourceType (this was how it was being done already), and puts debug messages into the database.  The database log just adds on a timestamp and location to the message, and the files define their own location when they import the debug function.