### PR TITLE
resolve js files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
 		filename: 'bundle.js'
 	},
 	watch: watch,
+    resolve: { extensions: ["*", ".js", ".jsx"] },
 	module: {
 		rules: [
 			{

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
 		filename: 'bundle.js'
 	},
 	watch: watch,
-    resolve: { extensions: ["*", ".js", ".jsx"] },
+    resolve: { extensions: [".js", ".jsx"] },
 	module: {
 		rules: [
 			{


### PR DESCRIPTION
Webpack config was missing a line, missed it when it was originally pulled in because of the way things were set up.  There were no errors with `App.jsx`, I think this is because `index.jsx` is the entry point and imports it, so it wasn't caught in the original pull request.

This should allow importing of js files.  Right now webpack isn't considering js files in the path valid modules to load, this will solve that problem.  If you want to test, just copy the missing line into your own webpack config file if its experiencing errors or checkout this branch and create some example directories and `.jsx` files to import.