### PR TITLE
Use fullUrl to access resources in DB

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@material-ui/lab": "^4.0.0-alpha.57",
     "axios": "^0.21.1",
     "babel-eslint": "^10.1.0",
+    "base64url": "^3.0.1",
     "debug": "~2.6.9",
     "dotenv": "^8.2.0",
     "eslint": "^7.19.0",

--- a/src/app.js
+++ b/src/app.js
@@ -83,7 +83,7 @@ app.use('/auth', authRouter);
 
 // Routes for collections
 Object.values(collections).forEach(collectionName => {
-  app.use(`/${collectionName}`, userAuthorization, genericController(collectionName));
+  app.use(`/collection/${collectionName}`, userAuthorization, genericController(collectionName));
 });
 
 // frontend

--- a/src/handlers/crudHandler.js
+++ b/src/handlers/crudHandler.js
@@ -2,7 +2,6 @@ const db = require('../storage/DataAccess');
 const express = require('express');
 const { StatusCodes } = require('http-status-codes');
 const { default: base64url } = require('base64url');
-const e = require('express');
 
 function createHandler(collectionName, req, res) {
   const newItem = req.body;

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -101,12 +101,12 @@ router.put('/:fullUrl/:resource/:resourceId', (req, res) => {
   const planDef = getPlanDef(req.params.fullUrl);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
-    const serverUrl = getBaseUrlFromFullUrl(fullUrl);
+    const serverUrl = getBaseUrlFromFullUrl(base64url.decode(req.params.fullUrl));
     const fullUrl = `${serverUrl}/${req.params.resource}/${req.params.resourceId}`;
     debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${fullUrl}`);
     const collection = `${req.body.resourceType.toLowerCase()}s`;
     db.upsert(collection, { fullUrl, ...req.body }, r => r.fullUrl === fullUrl);
-    startReportingWorkflow(planDef, fullUrl, req.body);
+    startReportingWorkflow(planDef, serverUrl, req.body);
   } else {
     res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -10,10 +10,12 @@ const {
   refreshKnowledgeArtifact,
   getEndpointId,
   subscriptionsFromPlanDef,
-  postSubscriptionsToEHR
+  postSubscriptionsToEHR,
+  getBaseUrlFromFullUrl
 } = require('../utils/fhir');
 const { getAccessToken } = require('../utils/client');
 const { PLANDEFINITIONS, ENDPOINTS } = require('../storage/collections');
+const { default: base64url } = require('base64url');
 const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
 
 /**
@@ -46,7 +48,12 @@ router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
     return;
   }
 
-  db.upsert(PLANDEFINITIONS, planDefinition, r => r.id === planDefinition.id);
+  const planDefinitionFullUrl = `${server.endpoint}/PlanDefinition/${planDefinition.id}`;
+  db.upsert(
+    PLANDEFINITIONS,
+    { fullUrl: planDefinitionFullUrl, ...planDefinition },
+    r => r.fullUrl === planDefinitionFullUrl
+  );
   debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
 
   const token = await getAccessToken(server.endpoint);
@@ -54,12 +61,17 @@ router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
   axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
     if (response.data) {
       const endpoint = response.data;
-      db.upsert(ENDPOINTS, endpoint, r => r.id === endpoint.id);
-      debug(`Fetched ${server.endpoint}/Endpoint/${endpoint.id}`);
+      const endpointFullUrl = `${server.endpoint}/Endpoint/${endpoint.id}`;
+      db.upsert(
+        ENDPOINTS,
+        { fullUrl: endpointFullUrl, ...endpoint },
+        r => r.fullUrl === endpointFullUrl
+      );
+      debug(`Fetched ${endpointFullUrl}`);
     }
   });
 
-  const subscriptions = subscriptionsFromPlanDef(planDefinition);
+  const subscriptions = subscriptionsFromPlanDef(planDefinition, server.endpoint);
   postSubscriptionsToEHR(subscriptions);
 
   res.sendStatus(StatusCodes.OK);
@@ -69,12 +81,12 @@ router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
  * Notification from EHR of changed data to start workflow process. The
  * id param is the PlanDefinition id which defines the workflow
  */
-router.post('/:id', (req, res) => {
-  const id = req.params.id;
-  const planDef = getPlanDef(id);
+router.post('/:fullUrl', (req, res) => {
+  const fullUrl = req.params.fullUrl;
+  const planDef = getPlanDef(fullUrl);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
-    startReportingWorkflow(planDef);
+    startReportingWorkflow(planDef, fullUrl);
   } else {
     res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
@@ -85,15 +97,16 @@ router.post('/:id', (req, res) => {
  * id param is the PlanDefinition if which defines the workflow. The body
  * contains the triggering resource.
  */
-router.put('/:id/:resource/:resourceId', (req, res) => {
-  const id = req.params.id;
-  const planDef = getPlanDef(id);
+router.put('/:fullUrl/:resource/:resourceId', (req, res) => {
+  const planDef = getPlanDef(req.params.fullUrl);
   if (planDef) {
     res.sendStatus(StatusCodes.OK);
-    debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${id}`);
+    const serverUrl = getBaseUrlFromFullUrl(fullUrl);
+    const fullUrl = `${serverUrl}/${req.params.resource}/${req.params.resourceId}`;
+    debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${fullUrl}`);
     const collection = `${req.body.resourceType.toLowerCase()}s`;
-    db.upsert(collection, req.body, r => r.id === req.body.id);
-    startReportingWorkflow(planDef, req.body);
+    db.upsert(collection, { fullUrl, ...req.body }, r => r.fullUrl === fullUrl);
+    startReportingWorkflow(planDef, fullUrl, req.body);
   } else {
     res.sendStatus(StatusCodes.NOT_FOUND); // 404
   }
@@ -102,11 +115,12 @@ router.put('/:id/:resource/:resourceId', (req, res) => {
 /**
  * Retrieves the PlanDefinition with the given id from the db
  *
- * @param {string} id - the id of the PlanDefinition
+ * @param {string} fullUrl - the base 64 url encoded fullUrl of the PlanDefinition
  * @returns the PlanDefinition with the given id or null if not found
  */
-function getPlanDef(id) {
-  const resultList = db.select(PLANDEFINITIONS, s => s.id === id);
+function getPlanDef(fullUrl) {
+  const decodedFullUrl = base64url.decode(fullUrl);
+  const resultList = db.select(PLANDEFINITIONS, s => s.fullUrl === decodedFullUrl);
   if (resultList[0]) return resultList[0];
   else return null;
 }

--- a/src/services/messaging.js
+++ b/src/services/messaging.js
@@ -39,7 +39,8 @@ function processMessage(req, res) {
     return;
   }
 
-  db.upsert(MESSAGES, messageBundle, r => r.id === messageBundle.id);
+  const fullUrl = `${messageHeader.source.endpoint}/Bundle/${messageBundle.id}`;
+  db.upsert(MESSAGES, { fullUrl, ...messageBundle }, r => r.fullUrl === fullUrl);
   debug(`Message bundle ${messageBundle.id} added to database`);
 
   forwardMessageResponse(messageBundle).then(() =>

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -183,7 +183,8 @@ const baseIgActions = {
           const resources = result.data.entry.map(e => {
             const resource = e.resource;
             const collection = `${resource.resourceType.toLowerCase()}s`;
-            db.upsert(collection, resource, r => r.id === resource.id);
+            const fullUrl = `${getEHRServer().endpoint}/${resource.resourceType}/${resource.id}`;
+            db.upsert(collection, { fullUrl, ...resource }, r => r.fullUrl === fullUrl);
             return resource;
           });
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -47,10 +47,10 @@ function subscriptionAuthorization(req, res, next) {
   else if (token) {
     const subscriptionId = token.split(':')[0];
     if (subscriptionId) {
-      const subscription = db.select(SUBSCRIPTIONS, s => s.id === subscriptionId);
-      if (subscription.length) {
+      const subscriptions = db.select(SUBSCRIPTIONS, s => s.id === subscriptionId);
+      for (const subscription of subscriptions) {
         // Get the authorization token from the subscription
-        const authorizationHeader = subscription[0].channel.header[0];
+        const authorizationHeader = subscription.channel.header[0];
         const authToken = authorizationHeader.split('Authorization: Bearer ')[1];
         if (token === authToken) return next();
       }

--- a/src/utils/reporting_workflow.js
+++ b/src/utils/reporting_workflow.js
@@ -53,9 +53,10 @@ const IG_REGISTRY = {
  * initializes the context and begins the executeWorkflow
  *
  * @param {PlanDefinition} planDef - the PlanDefinition resource
+ * @param {string} serverUrl - the server base url the PlanDefinition came from
  * @param {*} resource - the resource which triggered the notification
  */
-async function startReportingWorkflow(planDef, resource = null) {
+async function startReportingWorkflow(planDef, serverUrl, resource = null) {
   // TODO: MEDMORPH-49 to make sure the resource is always included
   if (!resource) return;
 
@@ -75,7 +76,8 @@ async function startReportingWorkflow(planDef, resource = null) {
 
   // Get the endpoint to submit the report to from the PlanDefinition
   const endpointId = getEndpointId(planDef);
-  const endpoint = db.select(ENDPOINTS, e => e.id === endpointId);
+  const endpointFullUrl = `${serverUrl}/Endpoint/${endpointId}`;
+  const endpoint = db.select(ENDPOINTS, e => e.fullUrl === endpointFullUrl);
   const destEndpoint = endpoint[0].address;
 
   // QUESTION: Should encounter and patient be saved to the database?


### PR DESCRIPTION
Replace all uses of insert/upsert/select for FHIR resources which use id to instead use fullUrl. This required a little refactoring, most notably changing subscription notifications to include the fullUrl. I did not update non-fhir collections such as servers.
I did some testing but since this touches a lot of different pieces looking for some help to make sure I didn't accidentally break anything.