### PR TITLE
Receive R5 Subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20462,17 +20462,17 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "lodash": {
           "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "resolved": false,
           "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         },
         "path": {
           "version": "0.12.7",
-          "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+          "resolved": false,
           "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
           "requires": {
             "process": "^0.11.1",
@@ -20481,12 +20481,12 @@
         },
         "process": {
           "version": "0.11.10",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "resolved": false,
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         },
         "util": {
           "version": "0.10.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+          "resolved": false,
           "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
           "requires": {
             "inherits": "2.0.3"
@@ -20494,7 +20494,7 @@
         },
         "xml-js": {
           "version": "1.6.8",
-          "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.8.tgz",
+          "resolved": false,
           "integrity": "sha512-kUv/geyN80d+s1T68uBfjoz+PjNUjwwf5AWWRwKRqqQaGozpMVsFsKYnenPsxlbN/VL7f0ia8NfLLPCDwX+95Q==",
           "requires": {
             "sax": "^1.2.4"

--- a/src/routes/subscriptions.js
+++ b/src/routes/subscriptions.js
@@ -1,128 +1,31 @@
-const { StatusCodes } = require('http-status-codes');
-
 const express = require('express');
 const router = express.Router();
-const axios = require('axios');
-const db = require('../storage/DataAccess');
-const { startReportingWorkflow } = require('../utils/reporting_workflow');
-const { getServerById } = require('../storage/servers');
-const {
-  refreshKnowledgeArtifact,
-  getEndpointId,
-  subscriptionsFromPlanDef,
-  postSubscriptionsToEHR,
-  getBaseUrlFromFullUrl
-} = require('../utils/fhir');
-const { getAccessToken } = require('../utils/client');
-const { PLANDEFINITIONS, ENDPOINTS } = require('../storage/collections');
-const { default: base64url } = require('base64url');
-const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
+const notificationService = require('../services/subscriptions');
 
 /**
  * Notification from KA Repo to refresh artifacts. The id param is the
  * server id from the database
  */
-router.post('/ka/:id', (req, res) => {
-  const id = req.params.id;
-  const server = getServerById(id);
-  if (server) {
-    refreshKnowledgeArtifact(server);
-    debug(`Recieved notification to refresh knowledge artifacts for server with id ${id}`);
-    res.sendStatus(StatusCodes.OK);
-  } else res.sendStatus(StatusCodes.NOT_FOUND);
-});
+router.post('/ka/:id', notificationService.knowledgeArtifact);
 
 /**
  * Notification from KA Repo to refresh artifacts. The id param is the
  * server id from the database and resourceId is the PlanDefinition id.
  * The body contains the triggering PlanDefinition
  */
-router.put('/ka/:id/:resource/:resourceId', async (req, res) => {
-  const id = req.params.id;
-  const planDefinition = req.body;
-  const endpointId = getEndpointId(planDefinition);
-  const server = getServerById(id);
-
-  if (!server) {
-    res.sendStatus(StatusCodes.NOT_FOUND);
-    return;
-  }
-
-  const planDefinitionFullUrl = `${server.endpoint}/PlanDefinition/${planDefinition.id}`;
-  db.upsert(
-    PLANDEFINITIONS,
-    { fullUrl: planDefinitionFullUrl, ...planDefinition },
-    r => r.fullUrl === planDefinitionFullUrl
-  );
-  debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
-
-  const token = await getAccessToken(server.endpoint);
-  const headers = { Authorization: `Bearer ${token}` };
-  axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
-    if (response.data) {
-      const endpoint = response.data;
-      const endpointFullUrl = `${server.endpoint}/Endpoint/${endpoint.id}`;
-      db.upsert(
-        ENDPOINTS,
-        { fullUrl: endpointFullUrl, ...endpoint },
-        r => r.fullUrl === endpointFullUrl
-      );
-      debug(`Fetched ${endpointFullUrl}`);
-    }
-  });
-
-  const subscriptions = subscriptionsFromPlanDef(planDefinition, server.endpoint);
-  postSubscriptionsToEHR(subscriptions);
-
-  res.sendStatus(StatusCodes.OK);
-});
+router.put('/ka/:id/:resource/:resourceId', notificationService.knowledgeArtifact);
 
 /**
  * Notification from EHR of changed data to start workflow process. The
  * id param is the PlanDefinition id which defines the workflow
  */
-router.post('/:fullUrl', (req, res) => {
-  const fullUrl = req.params.fullUrl;
-  const planDef = getPlanDef(fullUrl);
-  if (planDef) {
-    res.sendStatus(StatusCodes.OK);
-    startReportingWorkflow(planDef, fullUrl);
-  } else {
-    res.sendStatus(StatusCodes.NOT_FOUND); // 404
-  }
-});
+router.post('/:fullUrl', notificationService.reportTrigger);
 
 /**
  * Notification from EHR of changed data to start workflow process. The
  * id param is the PlanDefinition if which defines the workflow. The body
  * contains the triggering resource.
  */
-router.put('/:fullUrl/:resource/:resourceId', (req, res) => {
-  const planDef = getPlanDef(req.params.fullUrl);
-  if (planDef) {
-    res.sendStatus(StatusCodes.OK);
-    const serverUrl = getBaseUrlFromFullUrl(base64url.decode(req.params.fullUrl));
-    const fullUrl = `${serverUrl}/${req.params.resource}/${req.params.resourceId}`;
-    debug(`Received ${req.params.resource}/${req.params.resourceId} from subscription ${fullUrl}`);
-    const collection = `${req.body.resourceType.toLowerCase()}s`;
-    db.upsert(collection, { fullUrl, ...req.body }, r => r.fullUrl === fullUrl);
-    startReportingWorkflow(planDef, serverUrl, req.body);
-  } else {
-    res.sendStatus(StatusCodes.NOT_FOUND); // 404
-  }
-});
-
-/**
- * Retrieves the PlanDefinition with the given id from the db
- *
- * @param {string} fullUrl - the base 64 url encoded fullUrl of the PlanDefinition
- * @returns the PlanDefinition with the given id or null if not found
- */
-function getPlanDef(fullUrl) {
-  const decodedFullUrl = base64url.decode(fullUrl);
-  const resultList = db.select(PLANDEFINITIONS, s => s.fullUrl === decodedFullUrl);
-  if (resultList[0]) return resultList[0];
-  else return null;
-}
+router.put('/:fullUrl/:resource/:resourceId', notificationService.reportTrigger);
 
 module.exports = router;

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -149,14 +149,16 @@ function knowledgeArtifactFullResourceHandler(planDefinitions, serverUrl, res) {
       { fullUrl: planDefinitionFullUrl, ...planDefinition },
       r => r.fullUrl === planDefinitionFullUrl
     );
-    debug(`Fetched ${serverUrl}/PlanDefinition/${planDefinition.id}`);
+    debug(
+      `KA full-resource notification contained ${serverUrl}/PlanDefinition/${planDefinition.id}`
+    );
 
     const token = await getAccessToken(serverUrl);
     const headers = { Authorization: `Bearer ${token}` };
     axios.get(`${serverUrl}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
       if (response.data) {
         const endpoint = response.data;
-        const endpointFullUrl = `${endpoint}/Endpoint/${endpoint.id}`;
+        const endpointFullUrl = `${serverUrl}/Endpoint/${endpoint.id}`;
         db.upsert(
           ENDPOINTS,
           { fullUrl: endpointFullUrl, ...endpoint },

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -5,87 +5,123 @@ const db = require('../storage/DataAccess');
 const { startReportingWorkflow } = require('../utils/reporting_workflow');
 const { getServerById } = require('../storage/servers');
 const {
-  refreshKnowledgeArtifact,
   getEndpointId,
   subscriptionsFromPlanDef,
   postSubscriptionsToEHR,
-  getBaseUrlFromFullUrl
+  getBaseUrlFromFullUrl,
+  topicToResourceType
 } = require('../utils/fhir');
 const { getAccessToken } = require('../utils/client');
 const { PLANDEFINITIONS, ENDPOINTS } = require('../storage/collections');
 const { default: base64url } = require('base64url');
 const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
+const error = require('../storage/logs').error('medmorph-backend:subscriptions');
 
 /**
  * Handle KA notifications
  */
 async function knowledgeArtifact(req, res) {
   const id = req.params.id;
+  const bundle = req.body;
   const server = getServerById(id);
 
-  if (!server) {
-    res.sendStatus(StatusCodes.NOT_FOUND);
-    return;
-  }
+  if (!server) res.sendStatus(StatusCodes.NOT_FOUND);
+  else if (bundle.entry.length <= 1) {
+    // TODO: MEDMORPH-50 will implement this for payload type "empty"
+    error(`Unsupported notification payload type 'empty' from Bundle/${bundle.id}`);
+    res.sendStatus(StatusCode.BAD_REQUEST);
+  } else {
+    const planDefinitions = bundle.entry.reduce((filtered, entry) => {
+      if (entry.resource?.resourceType === 'PlanDefinition') filtered.push(entry.resource);
+      return filtered;
+    }, []);
 
-  if (req.body) {
-    // Notification from /ka/:id/:resource/:resourceId
-    const planDefinition = req.body;
-    const endpointId = getEndpointId(planDefinition);
+    if (!planDefinitions.length) {
+      // TODO: MEDMORPH-50 will implement this for payload type "id-only"
+      error(`Unsupported notification payload type 'id-only' from Bundle/${bundle.id}`);
+      res.sendStatus(StatusCodes.BAD_REQUEST);
+    }
 
-    const planDefinitionFullUrl = `${server.endpoint}/PlanDefinition/${planDefinition.id}`;
-    db.upsert(
-      PLANDEFINITIONS,
-      { fullUrl: planDefinitionFullUrl, ...planDefinition },
-      r => r.fullUrl === planDefinitionFullUrl
-    );
-    debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
+    planDefinitions.forEach(async planDefinition => {
+      const endpointId = getEndpointId(planDefinition);
+      const planDefinitionFullUrl = `${server.endpoint}/PlanDefinition/${planDefinition.id}`;
+      db.upsert(
+        PLANDEFINITIONS,
+        { fullUrl: planDefinitionFullUrl, ...planDefinition },
+        r => r.fullUrl === planDefinitionFullUrl
+      );
+      debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
 
-    const token = await getAccessToken(server.endpoint);
-    const headers = { Authorization: `Bearer ${token}` };
-    axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
-      if (response.data) {
-        const endpoint = response.data;
-        const endpointFullUrl = `${server.endpoint}/Endpoint/${endpoint.id}`;
-        db.upsert(
-          ENDPOINTS,
-          { fullUrl: endpointFullUrl, ...endpoint },
-          r => r.fullUrl === endpointFullUrl
-        );
-        debug(`Fetched ${endpointFullUrl}`);
-      }
+      const token = await getAccessToken(server.endpoint);
+      const headers = { Authorization: `Bearer ${token}` };
+      axios
+        .get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers })
+        .then(response => {
+          if (response.data) {
+            const endpoint = response.data;
+            const endpointFullUrl = `${server.endpoint}/Endpoint/${endpoint.id}`;
+            db.upsert(
+              ENDPOINTS,
+              { fullUrl: endpointFullUrl, ...endpoint },
+              r => r.fullUrl === endpointFullUrl
+            );
+            debug(`Fetched ${endpointFullUrl}`);
+          }
+        });
+
+      const subscriptions = subscriptionsFromPlanDef(planDefinition, server.endpoint);
+      postSubscriptionsToEHR(subscriptions);
     });
 
-    const subscriptions = subscriptionsFromPlanDef(planDefinition, server.endpoint);
-    postSubscriptionsToEHR(subscriptions);
-  } else {
-    // Notification from /ka/:id
-    refreshKnowledgeArtifact(server);
-    debug(`Recieved notification to refresh knowledge artifacts for server with id ${id}`);
+    res.sendStatus(StatusCodes.OK);
   }
-
-  res.sendStatus(StatusCodes.OK);
 }
 
 /**
  * Handle EHR Notifications and begin reporting workflow
  */
 function reportTrigger(req, res) {
-  const { fullUrl, resource: resourceType, resourceId } = req.params;
+  const bundle = req.body;
+  const { fullUrl } = req.params;
   const planDefFullUrl = base64url.decode(fullUrl);
   const serverUrl = getBaseUrlFromFullUrl(planDefFullUrl);
   const planDef = getPlanDef(planDefFullUrl);
-  if (planDef) {
-    res.sendStatus(StatusCodes.OK);
-    if (resourceType && resourceId && req.body) {
-      const resourceFullUrl = `${serverUrl}/${resourceType}/${resourceId}`;
-      debug(`Received ${resourceType}/${resourceId} from subscription ${resourceFullUrl}`);
-      const collection = `${resourceType.toLowerCase()}s`;
-      db.upsert(collection, { resourceFullUrl, ...req.body }, r => r.fullUrl === resourceFullUrl);
-    }
-    startReportingWorkflow(planDef, serverUrl, req.body);
+
+  if (!planDef) res.sendStatus(StatusCodes.NOT_FOUND);
+  else if (bundle.entry.length <= 1) {
+    // TODO: MEDMORPH-50 will implement this for payload type "empty"
+    error(`Unsupported notification payload type 'empty' from Bundle/${bundle.id}`);
+    res.sendStatus(StatusCodes.BAD_REQUEST);
   } else {
-    res.sendStatus(StatusCodes.NOT_FOUND); // 404
+    // Filter to only resource(s) which triggered the notification
+    const parameters = bundle.entry[0].resource;
+    const topic = parameters.parameter.find(p => p.name === 'topic').valueCanonical;
+    const resourceType = topicToResourceType(topic);
+    const resources = bundle.entry.reduce((filtered, entry) => {
+      if (entry.resource?.resourceType === resourceType) filtered.push(entry.resource);
+      return filtered;
+    }, []);
+
+    if (!resources.length) {
+      // TODO: MEDMORPH-50 will implement this for payload type "id-only"
+      error(`Unsupported notification payload type 'id-only' from Bundle/${bundle.id}`);
+      res.sendStatus(StatusCodes.BAD_REQUEST);
+    }
+
+    // For each triggering resource save to the db and begin reporting workflow
+    resources.forEach(resource => {
+      const resourceFullUrl = `${serverUrl}/${resourceType}/${resource.id}`;
+      debug(`Received ${resourceType}/${resource.id} from subscription ${resourceFullUrl}`);
+      const collection = `${resourceType.toLowerCase()}s`;
+      db.upsert(
+        collection,
+        { fullUrl: resourceFullUrl, ...resource },
+        r => r.fullUrl === resourceFullUrl
+      );
+      startReportingWorkflow(planDef, serverUrl, resource);
+    });
+
+    res.sendStatus(StatusCodes.OK);
   }
 }
 

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -1,0 +1,98 @@
+const { StatusCodes } = require('http-status-codes');
+
+const axios = require('axios');
+const db = require('../storage/DataAccess');
+const { startReportingWorkflow } = require('../utils/reporting_workflow');
+const { getServerById } = require('../storage/servers');
+const {
+  refreshKnowledgeArtifact,
+  getEndpointId,
+  subscriptionsFromPlanDef,
+  postSubscriptionsToEHR,
+  getBaseUrlFromFullUrl
+} = require('../utils/fhir');
+const { getAccessToken } = require('../utils/client');
+const { PLANDEFINITIONS, ENDPOINTS } = require('../storage/collections');
+const { default: base64url } = require('base64url');
+const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
+
+async function knowledgeArtifact(req, res) {
+  const id = req.params.id;
+  const server = getServerById(id);
+
+  if (!server) {
+    res.sendStatus(StatusCodes.NOT_FOUND);
+    return;
+  }
+
+  if (req.body) {
+    // Notification from /ka/:id/:resource/:resourceId
+    const planDefinition = req.body;
+    const endpointId = getEndpointId(planDefinition);
+
+    const planDefinitionFullUrl = `${server.endpoint}/PlanDefinition/${planDefinition.id}`;
+    db.upsert(
+      PLANDEFINITIONS,
+      { fullUrl: planDefinitionFullUrl, ...planDefinition },
+      r => r.fullUrl === planDefinitionFullUrl
+    );
+    debug(`Fetched ${server.endpoint}/PlanDefinition/${planDefinition.id}`);
+
+    const token = await getAccessToken(server.endpoint);
+    const headers = { Authorization: `Bearer ${token}` };
+    axios.get(`${server.endpoint}/Endpoint/${endpointId}`, { headers: headers }).then(response => {
+      if (response.data) {
+        const endpoint = response.data;
+        const endpointFullUrl = `${server.endpoint}/Endpoint/${endpoint.id}`;
+        db.upsert(
+          ENDPOINTS,
+          { fullUrl: endpointFullUrl, ...endpoint },
+          r => r.fullUrl === endpointFullUrl
+        );
+        debug(`Fetched ${endpointFullUrl}`);
+      }
+    });
+
+    const subscriptions = subscriptionsFromPlanDef(planDefinition, server.endpoint);
+    postSubscriptionsToEHR(subscriptions);
+  } else {
+    // Notification from /ka/:id
+    refreshKnowledgeArtifact(server);
+    debug(`Recieved notification to refresh knowledge artifacts for server with id ${id}`);
+  }
+
+  res.sendStatus(StatusCodes.OK);
+}
+
+function reportTrigger(req, res) {
+  const { fullUrl, resource: resourceType, resourceId } = req.params;
+  const planDefFullUrl = base64url.decode(fullUrl);
+  const serverUrl = getBaseUrlFromFullUrl(planDefFullUrl);
+  const planDef = getPlanDef(planDefFullUrl);
+  if (planDef) {
+    res.sendStatus(StatusCodes.OK);
+    if (resourceType && resourceId && req.body) {
+      const resourceFullUrl = `${serverUrl}/${resourceType}/${resourceId}`;
+      debug(`Received ${resourceType}/${resourceId} from subscription ${resourceFullUrl}`);
+      const collection = `${resourceType.toLowerCase()}s`;
+      db.upsert(collection, { resourceFullUrl, ...req.body }, r => r.fullUrl === resourceFullUrl);
+    }
+    startReportingWorkflow(planDef, serverUrl, req.body);
+  } else {
+    res.sendStatus(StatusCodes.NOT_FOUND); // 404
+  }
+}
+
+/**
+ * Retrieves the PlanDefinition with the given id from the db
+ *
+ * @param {string} fullUrl - the fullUrl of the PlanDefinition
+ * @returns the PlanDefinition with the given id or null if not found
+ */
+function getPlanDef(fullUrl) {
+  const resultList = db.select(PLANDEFINITIONS, s => s.fullUrl === fullUrl);
+  if (resultList[0]) return resultList[0];
+  else return null;
+}
+
+module.exports = { knowledgeArtifact, reportTrigger };

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -29,7 +29,7 @@ async function knowledgeArtifact(req, res) {
   else if (bundle.entry.length <= 1) {
     // TODO: MEDMORPH-50 will implement this for payload type "empty"
     error(`Unsupported notification payload type 'empty' from Bundle/${bundle.id}`);
-    res.sendStatus(StatusCode.BAD_REQUEST);
+    res.sendStatus(StatusCodes.BAD_REQUEST);
   } else {
     const planDefinitions = bundle.entry.reduce((filtered, entry) => {
       if (entry.resource?.resourceType === 'PlanDefinition') filtered.push(entry.resource);

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -16,6 +16,9 @@ const { PLANDEFINITIONS, ENDPOINTS } = require('../storage/collections');
 const { default: base64url } = require('base64url');
 const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
 
+/**
+ * Handle KA notifications
+ */
 async function knowledgeArtifact(req, res) {
   const id = req.params.id;
   const server = getServerById(id);
@@ -64,6 +67,9 @@ async function knowledgeArtifact(req, res) {
   res.sendStatus(StatusCodes.OK);
 }
 
+/**
+ * Handle EHR Notifications and begin reporting workflow
+ */
 function reportTrigger(req, res) {
   const { fullUrl, resource: resourceType, resourceId } = req.params;
   const planDefFullUrl = base64url.decode(fullUrl);

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -283,7 +283,32 @@ function postSubscriptionsToEHR(subscriptions) {
  * @returns the Subscription.criteria string or null if Subscription is not applicable
  */
 function namedEventToCriteria(code) {
-  const parts = code.split('-');
+  const resourceType = namedEventToResourceType(code);
+
+  if (resourceType === 'Observation') return 'Observation?category=laboratory';
+  else return resourceType;
+}
+
+/**
+ * Take a topic url and return the resource type the topic will subscribe to.
+ *
+ * @param {string} topicUrl - the canonical url for the topic
+ * @returns the resource type which will trigger a notification for the named event
+ */
+function topicToResourceType(topicUrl) {
+  const namedEvent = topicUrl.split('/').slice(-1)[0];
+  return namedEventToResourceType(namedEvent);
+}
+
+/**
+ * Take a named event code and return the resource type the named event will subscribe to.
+ * This is not quite the Subscription.criteria string but will be used to construct that.
+ *
+ * @param {string} namedEvent - the named event code
+ * @returns the resource type which will trigger a notification for the named event
+ */
+function namedEventToResourceType(namedEvent) {
+  const parts = namedEvent.split('-');
 
   let resource;
   if (parts[0] === 'new' || parts[0] === 'modified') resource = parts[1];
@@ -299,7 +324,7 @@ function namedEventToCriteria(code) {
     case 'medication':
       return 'Medication';
     case 'labresult':
-      return 'Observation?category=laboratory';
+      return 'Observation';
     case 'order':
       return 'ServiceRequest';
     case 'procedure':
@@ -383,6 +408,7 @@ module.exports = {
   forwardMessageResponse,
   subscribeToKnowledgeArtifacts,
   postSubscriptionsToEHR,
+  topicToResourceType,
   getEndpointId,
   getBaseUrlFromFullUrl
 };

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -350,11 +350,14 @@ async function getReferencedResource(url, reference) {
     const [resourceType, id] = reference.split('/');
     const token = await getAccessToken(url);
     const headers = { Authorization: `Bearer ${token}` };
-    const resource = await axios.get(`${url}/${resourceType}/${id}`, { headers: headers });
-    debug(
-      `Retrieved reference resource ${resource.data.resourceType}/${resource.data.id} from ${url}`
-    );
-    return resource.data;
+    const resource = await axios
+      .get(`${url}/${resourceType}/${id}`, { headers: headers })
+      .then(response => response.data)
+      .catch(err => error(err));
+    if (resource) {
+      debug(`Retrieved reference resource ${resource.resourceType}/${resource.id} from ${url}`);
+      return resource.data;
+    } else return null;
   }
 
   // TODO: update to work with other reference types


### PR DESCRIPTION
Update notification endpoints to accept R5 Backport Subscriptions which come as a Bundle. Still unclear as to whether or not the PUT `{base url}/{resourceType}/{resourceId}` is used in the backport subscriptions