### PR TITLE
add table ui

### DIFF
--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -142,7 +142,7 @@ const Collections = props => {
               return (
                 <TableCell key={cellKey} style={{ whiteSpace: 'nowrap' }}>
                   {' '}
-                  {header === 'RESOURCE' ? (
+                  {header === 'resource' ? (
                     <ReactJson src={d} collapsed={true} enableClipboard={false} />
                   ) : (
                     d[header.value || header.toLowerCase()]

--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import axios from 'axios';
 import { useQuery } from 'react-query';
 import {
@@ -6,76 +6,198 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableHead,
-  TableRow
+  TableRow,
+  TablePagination
 } from '@material-ui/core';
 import ReactJson from 'react-json-view';
 import PropTypes from 'prop-types';
+import useStyles from './styles';
+import SortedTableHead from './SortedTableHead';
+import DeleteIcon from '@material-ui/icons/Delete';
+import CreateIcon from '@material-ui/icons/Create';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
 
 const Collections = props => {
+  const classes = useStyles();
   const { selectedCollection } = props;
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [order, setOrder] = useState('asc');
+  const [orderBy, setOrderBy] = useState('');
+
+  const handleChangePage = (event, newPage) => {
+    setPage(newPage);
+  };
+
+  function descendingComparator(a, b, orderBy) {
+    if (b[orderBy] < a[orderBy]) {
+      return -1;
+    }
+    if (b[orderBy] > a[orderBy]) {
+      return 1;
+    }
+    return 0;
+  }
+
+  function serverStatus(server) {
+    return server && true;
+  }
+
+  function getComparator(order, orderBy) {
+    return order === 'desc'
+      ? (a, b) => descendingComparator(a, b, orderBy.toLowerCase())
+      : (a, b) => -descendingComparator(a, b, orderBy.toLowerCase());
+  }
+
+  function stableSort(array, comparator) {
+    const stabilizedThis = array.map((el, index) => [el, index]);
+
+    stabilizedThis.sort((a, b) => {
+      const order = comparator(a[0], b[0]);
+      if (order !== 0) return order;
+      return a[1] - b[1];
+    });
+    return stabilizedThis.map(el => el[0]);
+  }
+
+  const handleRequestSort = (event, property) => {
+    const isAsc = orderBy === property && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+  };
+
+  const handleChangeRowsPerPage = event => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
 
   const { data } = useQuery(['collections', { selectedCollection }], () =>
     axios.get(`http://localhost:3000/collection/${selectedCollection}`)
   );
 
-  const getHeaders = () => {
+  const getInfo = () => {
+    let headers = [];
     switch (selectedCollection) {
       case '':
         return [];
       case 'servers':
-        return ['ID', 'NAME', 'ENDPOINT', 'TYPE'];
+        headers = [{ value: 'icon', label: '' }, 'NAME', 'ID', 'ENDPOINT', 'TYPE'];
+        return {
+          headers,
+          data: data.data.map(element => {
+            const icon = serverStatus(element) ? classes.greenIcon : classes.redIcon;
+            element.icon = <a className={icon}></a>;
+            return element;
+          }),
+          addButton: true
+        };
       case 'endpoints':
       case 'plandefinitions':
-        return ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'NAME', 'RESOURCE'];
+        headers = ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'NAME', 'RESOURCE'];
+        return {
+          headers,
+          data: data.data,
+          addButton: true
+        };
       case 'subscriptions':
-        return ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'CRITERIA', 'RESOURCE'];
+        headers = ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'CRITERIA', 'RESOURCE'];
+        return {
+          headers,
+          data: data.data,
+          addButton: true
+        };
       case 'logs':
-        return ['ID', 'TIMESTAMP', 'MESSAGE', 'LOCATION'];
+        headers = ['ID', 'TIMESTAMP', 'MESSAGE', 'LOCATION'];
+        return {
+          headers,
+          data: data.data,
+          addButton: false
+        };
       default:
-        return ['ID', 'RESOURCE'];
+        headers = ['ID', 'RESOURCE'];
+        return {
+          headers,
+          data: data.data,
+          addButton: false
+        };
     }
   };
 
-  const formatRows = () => {
-    if (!data) return [];
-    return data.data.map((d, i) => {
-      return (
-        <TableRow key={`${selectedCollection}-${i}`}>
-          {getHeaders().map((header, j) => {
-            const cellKey = `${i}-${j}`;
+  const infoBundle = data ? getInfo() : { headers: [], data: [], addButton: true };
 
-            return (
-              <TableCell key={cellKey}>
-                {' '}
-                {header === 'RESOURCE' ? (
-                  <ReactJson src={d} collapsed={true} />
-                ) : (
-                  d[header.value || header.toLowerCase()]
-                )}{' '}
-              </TableCell>
-            );
-          })}
-        </TableRow>
-      );
-    });
+  const formatRows = () => {
+    if (!infoBundle.data) return [];
+    return stableSort(infoBundle.data, getComparator(order, orderBy))
+      .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+      .map((d, i) => {
+        return (
+          <TableRow key={`${selectedCollection}-${i}`} classes={{ root: classes.tableRow }}>
+            {infoBundle.headers.map((header, j) => {
+              const cellKey = `${i}-${j}`;
+              return (
+                <TableCell key={cellKey} style={{ whiteSpace: 'nowrap' }}>
+                  {' '}
+                  {header === 'RESOURCE' ? (
+                    <ReactJson src={d} collapsed={true} enableClipboard={false} />
+                  ) : (
+                    d[header.value || header.toLowerCase()]
+                  )}{' '}
+                </TableCell>
+              );
+            })}
+            <TableCell>
+              <CreateIcon fontSize={'small'} color="secondary" classes={{ root: classes.icon }} />
+              <DeleteIcon fontSize={'small'} color="error" classes={{ root: classes.icon }} />
+            </TableCell>
+          </TableRow>
+        );
+      });
   };
 
   return (
-    <div>
-      {selectedCollection !== '' && (
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                {getHeaders().map(header => (
-                  <TableCell key={header}> {header.label || header} </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>{formatRows()}</TableBody>
-          </Table>
-        </TableContainer>
+    <div className={classes.collection}>
+      {selectedCollection !== '' && infoBundle.data && (
+        <>
+          <div className={classes.topBar}>
+            <span className={classes.topBarText}>{selectedCollection.toUpperCase()}</span>
+            {infoBundle.addButton && (
+              <Button
+                variant="contained"
+                classes={{ root: classes.addButton }}
+                color="secondary"
+                disableElevation
+                startIcon={<AddIcon />}
+              >
+                Add new
+              </Button>
+            )}
+          </div>
+          <div className={classes.break}></div>
+          <TableContainer>
+            <Table size="small">
+              <SortedTableHead
+                classes={classes}
+                order={order}
+                orderBy={orderBy}
+                onRequestSort={handleRequestSort}
+                headers={infoBundle.headers}
+              />
+              <TableBody>{formatRows()}</TableBody>
+            </Table>
+            <TablePagination
+              component="div"
+              count={infoBundle.data.length}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              onChangePage={handleChangePage}
+              backIconButtonProps={{
+                classes: classes.backButton
+              }}
+              onChangeRowsPerPage={handleChangeRowsPerPage}
+            />
+          </TableContainer>
+        </>
       )}
     </div>
   );

--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import axios from 'axios';
 import { useQuery } from 'react-query';
 import {
@@ -26,9 +26,13 @@ const Collections = props => {
   const [order, setOrder] = useState('asc');
   const [orderBy, setOrderBy] = useState('');
 
-  const handleChangePage = (event, newPage) => {
+  useEffect(() => {
+    setPage(0);
+  }, selectedCollection);
+
+  const handleChangePage = useCallback((event, newPage) => {
     setPage(newPage);
-  };
+  });
 
   function descendingComparator(a, b, orderBy) {
     if (b[orderBy] < a[orderBy]) {
@@ -46,8 +50,8 @@ const Collections = props => {
 
   function getComparator(order, orderBy) {
     return order === 'desc'
-      ? (a, b) => descendingComparator(a, b, orderBy.toLowerCase())
-      : (a, b) => -descendingComparator(a, b, orderBy.toLowerCase());
+      ? (a, b) => descendingComparator(a, b, orderBy)
+      : (a, b) => -descendingComparator(a, b, orderBy);
   }
 
   function stableSort(array, comparator) {
@@ -61,19 +65,19 @@ const Collections = props => {
     return stabilizedThis.map(el => el[0]);
   }
 
-  const handleRequestSort = (event, property) => {
+  const handleRequestSort = useCallback((event, property) => {
     const isAsc = orderBy === property && order === 'asc';
     setOrder(isAsc ? 'desc' : 'asc');
     setOrderBy(property);
-  };
+  });
 
-  const handleChangeRowsPerPage = event => {
+  const handleChangeRowsPerPage = useCallback(event => {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
-  };
+  });
 
   const { data } = useQuery(['collections', { selectedCollection }], () =>
-    axios.get(`http://localhost:3000/collection/${selectedCollection}`)
+    axios.get(`/collection/${selectedCollection}`)
   );
 
   const getInfo = () => {
@@ -82,7 +86,7 @@ const Collections = props => {
       case '':
         return [];
       case 'servers':
-        headers = [{ value: 'icon', label: '' }, 'NAME', 'ID', 'ENDPOINT', 'TYPE'];
+        headers = [{ value: 'icon', label: '' }, 'name', 'id', 'endpoint', 'type'];
         return {
           headers,
           data: data.data.map(element => {
@@ -94,28 +98,28 @@ const Collections = props => {
         };
       case 'endpoints':
       case 'plandefinitions':
-        headers = ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'NAME', 'RESOURCE'];
+        headers = ['id', 'fullUrl', 'name', 'resource'];
         return {
           headers,
           data: data.data,
           addButton: true
         };
       case 'subscriptions':
-        headers = ['ID', { value: 'fullUrl', label: 'FULLURL' }, 'CRITERIA', 'RESOURCE'];
+        headers = ['id', 'fullUrl', 'criteria', 'resource'];
         return {
           headers,
           data: data.data,
           addButton: true
         };
       case 'logs':
-        headers = ['ID', 'TIMESTAMP', 'MESSAGE', 'LOCATION'];
+        headers = ['id', 'timestamp', 'message', 'location'];
         return {
           headers,
           data: data.data,
           addButton: false
         };
       default:
-        headers = ['ID', 'RESOURCE'];
+        headers = ['id', 'resource'];
         return {
           headers,
           data: data.data,

--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -155,48 +155,60 @@ const Collections = props => {
       });
   };
 
+  const renderToolbar = () => {
+    return (
+      <>
+        <div className={classes.topBar}>
+          <span className={classes.topBarText}>{selectedCollection.toUpperCase()}</span>
+          {infoBundle.addButton && (
+            <Button
+              variant="contained"
+              classes={{ root: classes.addButton }}
+              color="secondary"
+              disableElevation
+              startIcon={<AddIcon />}
+            >
+              Add new
+            </Button>
+          )}
+        </div>
+        <div className={classes.break}></div>
+      </>
+    );
+  };
+
   return (
     <div className={classes.collection}>
       {selectedCollection !== '' && infoBundle.data && (
         <>
-          <div className={classes.topBar}>
-            <span className={classes.topBarText}>{selectedCollection.toUpperCase()}</span>
-            {infoBundle.addButton && (
-              <Button
-                variant="contained"
-                classes={{ root: classes.addButton }}
-                color="secondary"
-                disableElevation
-                startIcon={<AddIcon />}
-              >
-                Add new
-              </Button>
-            )}
-          </div>
-          <div className={classes.break}></div>
-          <TableContainer>
-            <Table size="small">
-              <SortedTableHead
-                classes={classes}
-                order={order}
-                orderBy={orderBy}
-                onRequestSort={handleRequestSort}
-                headers={infoBundle.headers}
+          {renderToolbar()}
+          {infoBundle.data.length > 0 ? (
+            <TableContainer>
+              <Table size="small">
+                <SortedTableHead
+                  classes={classes}
+                  order={order}
+                  orderBy={orderBy}
+                  onRequestSort={handleRequestSort}
+                  headers={infoBundle.headers}
+                />
+                <TableBody>{formatRows()}</TableBody>
+              </Table>
+              <TablePagination
+                component="div"
+                count={infoBundle.data.length}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                onChangePage={handleChangePage}
+                backIconButtonProps={{
+                  classes: classes.backButton
+                }}
+                onChangeRowsPerPage={handleChangeRowsPerPage}
               />
-              <TableBody>{formatRows()}</TableBody>
-            </Table>
-            <TablePagination
-              component="div"
-              count={infoBundle.data.length}
-              rowsPerPage={rowsPerPage}
-              page={page}
-              onChangePage={handleChangePage}
-              backIconButtonProps={{
-                classes: classes.backButton
-              }}
-              onChangeRowsPerPage={handleChangeRowsPerPage}
-            />
-          </TableContainer>
+            </TableContainer>
+          ) : (
+            <div className={classes.noData}>No Data Found</div>
+          )}
         </>
       )}
     </div>

--- a/src/ui/components/Collections/SortedTableHead.jsx
+++ b/src/ui/components/Collections/SortedTableHead.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { TableCell, TableHead, TableRow, TableSortLabel } from '@material-ui/core';
 import PropTypes from 'prop-types';
 
 function SortedTableHead(props) {
   const { classes, order, orderBy, onRequestSort, headers } = props;
-  const createSortHandler = property => event => {
+  const createSortHandler = useCallback(property => event => {
     onRequestSort(event, property);
-  };
+  });
 
   const labels = headers.map(header => {
     if (header.value !== undefined) {
@@ -31,7 +31,7 @@ function SortedTableHead(props) {
               direction={orderBy === headCell.value ? order : 'asc'}
               onClick={createSortHandler(headCell.value)}
             >
-              {headCell.label}
+              {headCell.label.toUpperCase()}
               {orderBy === headCell.value ? (
                 <span className={classes.visuallyHidden}>
                   {order === 'desc' ? 'sorted descending' : 'sorted ascending'}

--- a/src/ui/components/Collections/SortedTableHead.jsx
+++ b/src/ui/components/Collections/SortedTableHead.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { TableCell, TableHead, TableRow, TableSortLabel } from '@material-ui/core';
+import PropTypes from 'prop-types';
+
+function SortedTableHead(props) {
+  const { classes, order, orderBy, onRequestSort, headers } = props;
+  const createSortHandler = property => event => {
+    onRequestSort(event, property);
+  };
+
+  const labels = headers.map(header => {
+    if (header.value !== undefined) {
+      return header;
+    } else {
+      return { label: header, value: header };
+    }
+  });
+  return (
+    <TableHead>
+      <TableRow>
+        {labels.map(headCell => (
+          <TableCell
+            key={headCell.value}
+            align="left"
+            sortDirection={orderBy === headCell.value ? order : false}
+            size="small"
+          >
+            <TableSortLabel
+              classes={{ root: classes.headerCell }}
+              active={orderBy === headCell.value}
+              direction={orderBy === headCell.value ? order : 'asc'}
+              onClick={createSortHandler(headCell.value)}
+            >
+              {headCell.label}
+              {orderBy === headCell.value ? (
+                <span className={classes.visuallyHidden}>
+                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                </span>
+              ) : null}
+            </TableSortLabel>
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+}
+
+SortedTableHead.propTypes = {
+  classes: PropTypes.object.isRequired,
+  onRequestSort: PropTypes.func.isRequired,
+  order: PropTypes.oneOf(['asc', 'desc']).isRequired,
+  orderBy: PropTypes.string.isRequired,
+  headers: PropTypes.array.isRequired
+};
+
+export default SortedTableHead;

--- a/src/ui/components/Collections/styles.jsx
+++ b/src/ui/components/Collections/styles.jsx
@@ -10,7 +10,8 @@ export default makeStyles(
     break: {
       width: '100%',
       height: '0',
-      borderTop: '1px solid #eaeaeb'
+      borderTop: '1px solid',
+      borderColor: theme.palette.common.grayHighlight
     },
     collection: {
       margin: '60px auto',
@@ -59,7 +60,7 @@ export default makeStyles(
     },
     tableRow: {
       '&:nth-of-type(odd)': {
-        backgroundColor: '#eaeaeb'
+        backgroundColor: theme.palette.common.grayHighlight
       }
     },
     topBar: {

--- a/src/ui/components/Collections/styles.jsx
+++ b/src/ui/components/Collections/styles.jsx
@@ -53,6 +53,10 @@ export default makeStyles(
     headerCell: {
       color: 'black'
     },
+    noData: {
+      height: '60px',
+      lineHeight: '60px'
+    },
     tableRow: {
       '&:nth-of-type(odd)': {
         backgroundColor: '#eaeaeb'

--- a/src/ui/components/Collections/styles.jsx
+++ b/src/ui/components/Collections/styles.jsx
@@ -1,0 +1,76 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    addButton: {
+      float: 'right',
+      marginRight: '25px',
+      marginTop: '17px',
+      color: theme.palette.common.white
+    },
+    break: {
+      width: '100%',
+      height: '0',
+      borderTop: '1px solid #eaeaeb'
+    },
+    collection: {
+      margin: '60px auto',
+      width: '75vw',
+      backgroundColor: 'white'
+    },
+    visuallyHidden: {
+      border: 0,
+      clip: 'rect(0 0 0 0)',
+      height: 1,
+      margin: -1,
+      overflow: 'hidden',
+      padding: 0,
+      position: 'absolute',
+      top: 20,
+      width: 1
+    },
+    greenIcon: {
+      border: '2px solid white',
+      backgroundColor: theme.palette.common.turqoise,
+      width: '12px',
+      height: '12px',
+      display: 'flex',
+      borderRadius: '100px',
+      marginLeft: '12px'
+    },
+    redIcon: {
+      border: '2px solid white',
+      backgroundColor: theme.palette.common.red,
+      width: '12px',
+      height: '12px',
+      display: 'flex',
+      borderRadius: '100px',
+      marginLeft: '12px'
+    },
+    icon: {
+      marginRight: '10px',
+      cursor: 'pointer'
+    },
+    headerCell: {
+      color: 'black'
+    },
+    tableRow: {
+      '&:nth-of-type(odd)': {
+        backgroundColor: '#eaeaeb'
+      }
+    },
+    topBar: {
+      height: '70px',
+      lineHeight: '70px'
+    },
+    topBarText: {
+      float: 'left',
+      marginLeft: '20px'
+    },
+    backButton: {
+      color: 'red',
+      backgroundColor: 'red'
+    }
+  }),
+
+  { name: 'Collection', index: 1 }
+);

--- a/src/ui/components/Dashboard/styles.jsx
+++ b/src/ui/components/Dashboard/styles.jsx
@@ -47,8 +47,8 @@ export default makeStyles(
     cornerText: {
       fontSize: '20px',
       fontFamily: 'Verdana',
-      color: theme.palette.text.primary,
-      textAlign: 'center'
+      textAlign: 'center',
+      color: theme.palette.common.white
     },
 
     drawer: {
@@ -65,7 +65,8 @@ export default makeStyles(
       textAlign: 'left',
       paddingLeft: '35px',
       display: 'flex',
-      height: '70px'
+      height: '70px',
+      color: 'white'
     },
     drawerItemText: {
       fontFamily: 'Verdana',

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -37,8 +37,8 @@ const paletteBase = {
     primary: colors.grayLight
   },
   text: {
-    primary: colors.white,
-    secondary: colors.white,
+    primary: colors.black,
+    secondary: colors.black,
     gray: colors.grayLighter
   },
   grey: {
@@ -52,10 +52,35 @@ const paletteBase = {
 const materialUiOverridesBase = {
   MuiTableCell: {
     body: {
-      color: 'black'
+      color: '#575b62'
     },
     head: {
-      color: 'black'
+      color: '#575b62',
+      fontWeight: '600',
+      fontSize: '12px'
+    },
+    sizeSmall: {
+      padding: '5px 24px 5px 16px',
+      '&:last-child': {
+        paddingRight: '0px',
+        width: '80px'
+      }
+    }
+  },
+  MuiTableContainer: {
+    root: {
+      width: '70vw',
+      margin: '0 20px 0 20px',
+      height: '450px',
+      backgroundColor: 'white'
+    }
+  },
+  MuiTableSortLabel: {
+    root: {
+      color: 'black',
+      '&$active': {
+        color: 'black'
+      }
     }
   }
 };

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -18,7 +18,8 @@ const colors = {
   grayVeryDark: '#3a3a3a',
   green: '#2fa874',
   purple: '#8b72d6',
-  turqoise: '#37c0ae'
+  turqoise: '#37c0ae',
+  grayHighlight: '#eaeaeb'
 };
 
 const paletteBase = {
@@ -71,7 +72,7 @@ const materialUiOverridesBase = {
     root: {
       width: '70vw',
       margin: '0 20px 0 20px',
-      height: '450px',
+      overflowX: 'visible',
       backgroundColor: 'white'
     }
   },

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -72,7 +72,8 @@ const materialUiOverridesBase = {
     root: {
       width: '70vw',
       margin: '0 20px 0 20px',
-      overflowX: 'visible',
+      overflowY: 'visible',
+      overflowX: 'scroll',
       backgroundColor: 'white'
     }
   },


### PR DESCRIPTION
The collections now are displayed in a table as shown in the designs.  The pagination works and you can sort the columns, but none of the buttons are functional.  The only differences from the design are some minor color/font and spacing issues and the "Add server" button being replaced with a generic "Add new" button.  This button could be changed to use the actual collections name, but we'd have to do a bit of extra processing.  

Different collections can be given different parameters as well, the "Add new" button won't show up for "Logs" and "Requests". 