### PR TITLE
Use env var for admin token

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -4,3 +4,4 @@ REALM=backend_app
 AUTH=http://moonshot-dev.mitre.org:8090/auth
 DATA_TRUST_SERVICE=http://localhost:3005
 BASE_URL=http://localhost:3000
+ADMIN_TOKEN=admin

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Certain configuration properties MUST be set via enviornment variables. The easi
 | DEBUG | No | Set to `medmorph-backend:*` to enable debug loggers for the app. |
 | DATA_TRUST_SERVICE | Yes | The base url for the data/trust service server. |
 | BASE_URL | Yes | The base url for this server. |
+| ADMIN_TOKEN | No | The value of the admin token to bypass authorization. If unset no admin token can be used. |
 
 ```env
 # Port number for the server, defaults to 3000 if not provided

--- a/src/__tests__/app.test.js
+++ b/src/__tests__/app.test.js
@@ -3,6 +3,7 @@ const app = require('../app');
 
 describe('Test the root path', () => {
   test('It should response the GET method', () => {
+    process.env.ADMIN_TOKEN = 'admin';
     return request(app)
       .get('/index')
       .set('Authorization', 'Bearer admin')

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -34,7 +34,8 @@ function generateToken(id) {
 function backendAuthorization(req, res, next) {
   // Check for admin token, otherwise proceed with keycloak authentication
   const token = getToken(req);
-  if (token === 'admin') return next();
+  const adminToken = process.env.ADMIN_TOKEN;
+  if (adminToken && token === adminToken) return next();
   else return passport.authenticate('keycloak', { session: false })(req, res, next);
 }
 
@@ -43,7 +44,8 @@ function backendAuthorization(req, res, next) {
  */
 function subscriptionAuthorization(req, res, next) {
   const token = getToken(req);
-  if (token === 'admin') return next();
+  const adminToken = process.env.ADMIN_TOKEN;
+  if (adminToken && token === adminToken) return next();
   else if (token) {
     const subscriptionId = token.split(':')[0];
     if (subscriptionId) {


### PR DESCRIPTION
Replaces the hardcoded admin token with an env variable. To test set `ADMIN_TOKEN` env var to a value and then verify you can use that to access `{base url}/index`.