### PR TITLE
Check Access Token Scope

### DIFF
--- a/src/handlers/crudHandler.js
+++ b/src/handlers/crudHandler.js
@@ -52,7 +52,7 @@ function deleteHandler(collectionName, req, res) {
     return;
   }
 
-  res.send(StatusCodes.OK);
+  res.sendStatus(StatusCodes.OK);
 }
 
 function genericController(collectionName) {

--- a/src/routes/wellknown.js
+++ b/src/routes/wellknown.js
@@ -5,7 +5,7 @@ router.get('/smart-configuration', (req, res) => {
   const smartConfiguration = {
     token_endpoint: process.env.AUTH_TOKEN_URL,
     response_types_supported: ['token'],
-    scopes_supported: ['offline_access', 'system/*.read']
+    scopes_supported: ['offline_access', 'system/*.*', 'system/*.read', 'system/*.write']
   };
   res.send(smartConfiguration);
 });


### PR DESCRIPTION
- Check access token scope before authorizing request
 - Added `system/*.*` and `system/*.write` scopes in addition to `system/*.read`
     - All requests are allowed when scope includes `system/*.*`
     - GET requests are allowed when scope includes `system/*.read`
     - POST, PUT, and DELETE requests are allowed when scope includes `system/*.write`
 - To test, you must first get an access token from the keycloak server. I added another client with the client_id `test` which made scopes optional. client_secret can be found on the keycloak server.
     - You should get a 401 with an "Insufficient scope" message if you don't have the correct scope.