### PR TITLE
Notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "http-status-codes": "^2.1.4",
         "jwks-rsa": "^2.0.2",
         "lokijs": "^1.5.11",
+        "moment": "^2.29.1",
         "morgan": "~1.9.1",
         "node-jose": "^2.0.0",
         "nodemon": "^2.0.7",
@@ -6505,7 +6506,11 @@
         "lodash",
         "path",
         "q",
-        "xml-js"
+        "xml-js",
+        "inherits",
+        "process",
+        "sax",
+        "util"
       ],
       "dependencies": {
         "lodash": "^4.17.19",
@@ -10815,6 +10820,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/morgan": {
@@ -25608,6 +25621,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "morgan": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "http-status-codes": "^2.1.4",
     "jwks-rsa": "^2.0.2",
     "lokijs": "^1.5.11",
+    "moment": "^2.29.1",
     "morgan": "~1.9.1",
     "node-jose": "^2.0.0",
     "nodemon": "^2.0.7",

--- a/src/services/test_service.js
+++ b/src/services/test_service.js
@@ -1,6 +1,6 @@
 const error = require('../storage/logs').error('medmorph-backend:test');
 module.exports = (req, res, next) => {
-  error('there was an error');
+  error('test error', 'Test Service: Test Notification');
   res.send('Howdy from test service!');
   next();
 };

--- a/src/services/test_service.js
+++ b/src/services/test_service.js
@@ -1,4 +1,6 @@
+const error = require('../storage/logs').error('medmorph-backend:test')
 module.exports = (req, res, next) => {
+  error("there was an error");
   res.send('Howdy from test service!');
   next();
 };

--- a/src/services/test_service.js
+++ b/src/services/test_service.js
@@ -1,6 +1,6 @@
-const error = require('../storage/logs').error('medmorph-backend:test')
+const error = require('../storage/logs').error('medmorph-backend:test');
 module.exports = (req, res, next) => {
-  error("there was an error");
+  error('there was an error');
   res.send('Howdy from test service!');
   next();
 };

--- a/src/storage/collections.js
+++ b/src/storage/collections.js
@@ -8,5 +8,6 @@ module.exports = {
   LOGS: 'logs',
   ERRORS: 'errors',
   MESSAGES: 'messages',
-  REQUESTS: 'requests'
+  REQUESTS: 'requests',
+  NOTIFICATIONS: 'notifications'
 };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -30,11 +30,11 @@ function error(location) {
     db.insert(ERRORS, log);
 
     const notification = {
-        id: uuidv4(),
-        timestamp: Date.now(),
-        notif: notif ? notif : error,
-        viewed: false,
-        type: 'error',
+      id: uuidv4(),
+      timestamp: Date.now(),
+      notif: notif ? notif : error,
+      viewed: false,
+      type: 'error'
     };
     db.insert(NOTIFICATIONS, notification);
   };

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -1,5 +1,5 @@
 const db = require('./DataAccess');
-const { LOGS, ERRORS, REQUESTS } = require('./collections');
+const { LOGS, ERRORS, REQUESTS, NOTIFICATIONS } = require('./collections');
 const debugConsole = require('debug');
 const { v4: uuidv4 } = require('uuid');
 
@@ -18,7 +18,7 @@ function debug(location) {
 }
 
 function error(location) {
-  return error => {
+  return (error, notif) => {
     const logger = debugConsole(location);
     logger(error);
     const log = {
@@ -28,6 +28,15 @@ function error(location) {
       location: location
     };
     db.insert(ERRORS, log);
+
+    const notification = {
+        id: uuidv4(),
+        timestamp: Date.now(),
+        notif: notif ? notif : error,
+        viewed: false,
+        type: 'error',
+    };
+    db.insert(NOTIFICATIONS, notification);
   };
 }
 

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -32,7 +32,7 @@ function error(location) {
     const notification = {
       id: uuidv4(),
       timestamp: Date.now(),
-      notif: notif ? notif : error,
+      notif: notif || error,
       viewed: false,
       type: 'error'
     };

--- a/src/ui/components/Dashboard/DashboardLayout.jsx
+++ b/src/ui/components/Dashboard/DashboardLayout.jsx
@@ -16,7 +16,7 @@ function DashboardLayout() {
 
   const unviewedNotifs = useMemo(() => {
     if (data) {
-      return data.data.filter(notif => (!notif.viewed))
+      return data.data.filter(notif => !notif.viewed);
     }
     return [];
   }, [data]);

--- a/src/ui/components/Dashboard/DashboardLayout.jsx
+++ b/src/ui/components/Dashboard/DashboardLayout.jsx
@@ -12,57 +12,63 @@ function DashboardLayout() {
   const classes = useStyles();
   const [contentKey, setContentKey] = useState('dashboard');
 
-  const { data } = useQuery(['notifications'], () =>
-    axios.get(`/collection/notifications`)
-  );
+  const { data } = useQuery(['notifications'], () => axios.get(`/collection/notifications`));
 
-  const unviewedNotifs = useMemo(()=>{
-    if(data) {
-        return data.data.filter((notif)=>{
-            return !notif.viewed
-        })
+  const unviewedNotifs = useMemo(() => {
+    if (data) {
+      return data.data.filter(notif => {
+        return !notif.viewed;
+      });
     } else {
-        return [];
+      return [];
     }
   }, [data]);
 
   const newNotifs = unviewedNotifs.length > 0;
   // can do useMemo to update labels like notifications
-  const tabs = useMemo(()=>{ 
+  const tabs = useMemo(() => {
     return [
-        { key: 'overview', label: 'Overview', component: null },
-        { key: 'dashboard', label: 'Dashboard', component: <Dashboard /> },
-        { key: 'notifications', label: `Notifications ${newNotifs ? `(${unviewedNotifs.length})` : ''}`, component: <Notifications notifs={unviewedNotifs}/> },
-        { key: 'collections', label: 'Collections', component: null },
-        { key: 'servers', label: 'Servers', component: <Collections selectedCollection="servers" /> },
-        {
+      { key: 'overview', label: 'Overview', component: null },
+      { key: 'dashboard', label: 'Dashboard', component: <Dashboard /> },
+      {
+        key: 'notifications',
+        label: `Notifications ${newNotifs ? `(${unviewedNotifs.length})` : ''}`,
+        component: <Notifications notifs={unviewedNotifs} />
+      },
+      { key: 'collections', label: 'Collections', component: null },
+      { key: 'servers', label: 'Servers', component: <Collections selectedCollection="servers" /> },
+      {
         key: 'endpoints',
         label: 'Endpoints',
         component: <Collections selectedCollection="endpoints" />
-        },
-        {
+      },
+      {
         key: 'subscriptions',
         label: 'Subscriptions',
         component: <Collections selectedCollection="subscriptions" />
-        },
-        {
+      },
+      {
         key: 'plandefinitions',
         label: 'Plan Definitions',
         component: <Collections selectedCollection="plandefinitions" />
-        },
-        { key: 'logs', label: 'Logs', component: <Collections selectedCollection="logs" /> },
-        {
+      },
+      { key: 'logs', label: 'Logs', component: <Collections selectedCollection="logs" /> },
+      {
         key: 'completedreports',
         label: 'Completed Reports',
         component: <Collections selectedCollection="completedreports" />
-        },
-        {
+      },
+      {
         key: 'reporting',
         label: 'Reporting',
         component: <Collections selectedCollection="reporting" />
-        },
-        { key: 'errors', label: 'Errors', component: <Collections selectedCollection="errors" /> },
-        { key: 'requests', label: 'Requests', component: <Collections selectedCollection="requests" /> }
+      },
+      { key: 'errors', label: 'Errors', component: <Collections selectedCollection="errors" /> },
+      {
+        key: 'requests',
+        label: 'Requests',
+        component: <Collections selectedCollection="requests" />
+      }
     ];
   });
 
@@ -74,7 +80,7 @@ function DashboardLayout() {
 
   return (
     <div className={classes.container}>
-      <NavBar newNotifs={newNotifs} callback={setContentKey}/>
+      <NavBar newNotifs={newNotifs} callback={setContentKey} />
       <Sidebar tabs={tabs} callback={setContentKey} selected={contentKey} />
       <main className={classes.content}>
         <div className={classes.spacer} />

--- a/src/ui/components/Dashboard/DashboardLayout.jsx
+++ b/src/ui/components/Dashboard/DashboardLayout.jsx
@@ -16,12 +16,9 @@ function DashboardLayout() {
 
   const unviewedNotifs = useMemo(() => {
     if (data) {
-      return data.data.filter(notif => {
-        return !notif.viewed;
-      });
-    } else {
-      return [];
+      return data.data.filter(notif => (!notif.viewed))
     }
+    return [];
   }, [data]);
 
   const newNotifs = unviewedNotifs.length > 0;
@@ -80,7 +77,7 @@ function DashboardLayout() {
 
   return (
     <div className={classes.container}>
-      <NavBar newNotifs={newNotifs} callback={setContentKey} />
+      <NavBar newNotifs={newNotifs} setContentKey={setContentKey} />
       <Sidebar tabs={tabs} callback={setContentKey} selected={contentKey} />
       <main className={classes.content}>
         <div className={classes.spacer} />

--- a/src/ui/components/Dashboard/DashboardLayout.jsx
+++ b/src/ui/components/Dashboard/DashboardLayout.jsx
@@ -1,49 +1,70 @@
 import React, { useState, useMemo, memo } from 'react';
+import axios from 'axios';
+import { useQuery } from 'react-query';
 import useStyles from './styles';
 import Sidebar from './Sidebar';
 import NavBar from './NavBar';
 import Collections from '../Collections';
 import Dashboard from './Dashboard';
+import Notifications from '../Notifications';
 
 function DashboardLayout() {
   const classes = useStyles();
   const [contentKey, setContentKey] = useState('dashboard');
+
+  const { data } = useQuery(['notifications'], () =>
+    axios.get(`/collection/notifications`)
+  );
+
+  const unviewedNotifs = useMemo(()=>{
+    if(data) {
+        return data.data.filter((notif)=>{
+            return !notif.viewed
+        })
+    } else {
+        return [];
+    }
+  }, [data]);
+
+  const newNotifs = unviewedNotifs.length > 0;
   // can do useMemo to update labels like notifications
-  const tabs = [
-    { key: 'overview', label: 'Overview', component: null },
-    { key: 'dashboard', label: 'Dashboard', component: <Dashboard /> },
-    { key: 'notifications', label: 'Notifications', component: <div>Notifications</div> },
-    { key: 'collections', label: 'Collections', component: null },
-    { key: 'servers', label: 'Servers', component: <Collections selectedCollection="servers" /> },
-    {
-      key: 'endpoints',
-      label: 'Endpoints',
-      component: <Collections selectedCollection="endpoints" />
-    },
-    {
-      key: 'subscriptions',
-      label: 'Subscriptions',
-      component: <Collections selectedCollection="subscriptions" />
-    },
-    {
-      key: 'plandefinitions',
-      label: 'Plan Definitions',
-      component: <Collections selectedCollection="plandefinitions" />
-    },
-    { key: 'logs', label: 'Logs', component: <Collections selectedCollection="logs" /> },
-    {
-      key: 'completedreports',
-      label: 'Completed Reports',
-      component: <Collections selectedCollection="completedreports" />
-    },
-    {
-      key: 'reporting',
-      label: 'Reporting',
-      component: <Collections selectedCollection="reporting" />
-    },
-    { key: 'errors', label: 'Errors', component: <Collections selectedCollection="errors" /> },
-    { key: 'requests', label: 'Requests', component: <Collections selectedCollection="requests" /> }
-  ];
+  const tabs = useMemo(()=>{ 
+    return [
+        { key: 'overview', label: 'Overview', component: null },
+        { key: 'dashboard', label: 'Dashboard', component: <Dashboard /> },
+        { key: 'notifications', label: `Notifications ${newNotifs ? `(${unviewedNotifs.length})` : ''}`, component: <Notifications notifs={unviewedNotifs}/> },
+        { key: 'collections', label: 'Collections', component: null },
+        { key: 'servers', label: 'Servers', component: <Collections selectedCollection="servers" /> },
+        {
+        key: 'endpoints',
+        label: 'Endpoints',
+        component: <Collections selectedCollection="endpoints" />
+        },
+        {
+        key: 'subscriptions',
+        label: 'Subscriptions',
+        component: <Collections selectedCollection="subscriptions" />
+        },
+        {
+        key: 'plandefinitions',
+        label: 'Plan Definitions',
+        component: <Collections selectedCollection="plandefinitions" />
+        },
+        { key: 'logs', label: 'Logs', component: <Collections selectedCollection="logs" /> },
+        {
+        key: 'completedreports',
+        label: 'Completed Reports',
+        component: <Collections selectedCollection="completedreports" />
+        },
+        {
+        key: 'reporting',
+        label: 'Reporting',
+        component: <Collections selectedCollection="reporting" />
+        },
+        { key: 'errors', label: 'Errors', component: <Collections selectedCollection="errors" /> },
+        { key: 'requests', label: 'Requests', component: <Collections selectedCollection="requests" /> }
+    ];
+  });
 
   const content = useMemo(() => {
     return tabs.find(tab => {
@@ -53,7 +74,7 @@ function DashboardLayout() {
 
   return (
     <div className={classes.container}>
-      <NavBar />
+      <NavBar newNotifs={newNotifs} callback={setContentKey}/>
       <Sidebar tabs={tabs} callback={setContentKey} selected={contentKey} />
       <main className={classes.content}>
         <div className={classes.spacer} />

--- a/src/ui/components/Dashboard/NavBar.jsx
+++ b/src/ui/components/Dashboard/NavBar.jsx
@@ -9,17 +9,17 @@ import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import Avatar from '@material-ui/core/Avatar';
 import MenuOpenIcon from '@material-ui/icons/MenuOpen';
 import Badge from '@material-ui/core/Badge';
-
+import PropTypes from 'prop-types';
 import Menu from './Menu';
 function NavBar(props) {
   const [open, setOpen] = useState(false);
   const { newNotifs, callback } = props;
   const classes = useStyles();
 
-  const setNotif = useCallback(()=>{
-      callback('notifications');
+  const setNotif = useCallback(() => {
+    callback('notifications');
   });
-  
+
   return (
     <div>
       <AppBar position="fixed" className={classes.appBar}>
@@ -37,7 +37,13 @@ function NavBar(props) {
             placeholder="Type a keyword..."
             fullWidth
           ></TextField>
-          <Badge classes={{badge: classes.badge, root: classes.badgeRoot}} onClick={setNotif} variant='dot' overlap="circle" invisible={!newNotifs}>
+          <Badge
+            classes={{ badge: classes.badge, root: classes.badgeRoot }}
+            onClick={setNotif}
+            variant="dot"
+            overlap="circle"
+            invisible={!newNotifs}
+          >
             <NotificationsNoneIcon className={classes.icon} fontSize={'large'} />
           </Badge>
           <Avatar className={classes.avatar}>NB</Avatar>
@@ -52,5 +58,10 @@ function NavBar(props) {
     </div>
   );
 }
+
+NavBar.propTypes = {
+  newNotifs: PropTypes.bool,
+  callback: PropTypes.func
+};
 
 export default memo(NavBar);

--- a/src/ui/components/Dashboard/NavBar.jsx
+++ b/src/ui/components/Dashboard/NavBar.jsx
@@ -13,11 +13,11 @@ import PropTypes from 'prop-types';
 import Menu from './Menu';
 function NavBar(props) {
   const [open, setOpen] = useState(false);
-  const { newNotifs, callback } = props;
+  const { newNotifs, setContentKey } = props;
   const classes = useStyles();
 
   const setNotif = useCallback(() => {
-    callback('notifications');
+    setContentKey('notifications');
   });
 
   return (
@@ -61,7 +61,7 @@ function NavBar(props) {
 
 NavBar.propTypes = {
   newNotifs: PropTypes.bool,
-  callback: PropTypes.func
+  setContentKey: PropTypes.func
 };
 
 export default memo(NavBar);

--- a/src/ui/components/Dashboard/NavBar.jsx
+++ b/src/ui/components/Dashboard/NavBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, memo } from 'react';
+import React, { useState, memo, useCallback } from 'react';
 import useStyles from './styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -8,11 +8,18 @@ import TextField from '@material-ui/core/TextField';
 import NotificationsNoneIcon from '@material-ui/icons/NotificationsNone';
 import Avatar from '@material-ui/core/Avatar';
 import MenuOpenIcon from '@material-ui/icons/MenuOpen';
-import Menu from './Menu';
-function NavBar() {
-  const [open, setOpen] = useState(false);
+import Badge from '@material-ui/core/Badge';
 
+import Menu from './Menu';
+function NavBar(props) {
+  const [open, setOpen] = useState(false);
+  const { newNotifs, callback } = props;
   const classes = useStyles();
+
+  const setNotif = useCallback(()=>{
+      callback('notifications');
+  });
+  
   return (
     <div>
       <AppBar position="fixed" className={classes.appBar}>
@@ -30,7 +37,9 @@ function NavBar() {
             placeholder="Type a keyword..."
             fullWidth
           ></TextField>
-          <NotificationsNoneIcon className={classes.icon} fontSize={'large'} />
+          <Badge classes={{badge: classes.badge, root: classes.badgeRoot}} onClick={setNotif} variant='dot' overlap="circle" invisible={!newNotifs}>
+            <NotificationsNoneIcon className={classes.icon} fontSize={'large'} />
+          </Badge>
           <Avatar className={classes.avatar}>NB</Avatar>
           <MenuOpenIcon
             className={classes.icon}

--- a/src/ui/components/Dashboard/styles.jsx
+++ b/src/ui/components/Dashboard/styles.jsx
@@ -18,16 +18,16 @@ export default makeStyles(
       margin: '0 15px 0 15px'
     },
     badge: {
-        backgroundColor: theme.palette.common.maroon,
-        top: '35%',
-        right: '35%',
-        border: '2px solid white',
-        borderRadius: '15px',
-        height: '13px',
-        width: '13px',
+      backgroundColor: theme.palette.common.maroon,
+      top: '35%',
+      right: '35%',
+      border: '2px solid white',
+      borderRadius: '15px',
+      height: '13px',
+      width: '13px'
     },
     badgeRoot: {
-        cursor: 'pointer',
+      cursor: 'pointer'
     },
     breakLine: {
       flexGrow: 1,

--- a/src/ui/components/Dashboard/styles.jsx
+++ b/src/ui/components/Dashboard/styles.jsx
@@ -21,7 +21,8 @@ export default makeStyles(
       backgroundColor: theme.palette.common.maroon,
       top: '35%',
       right: '35%',
-      border: '2px solid white',
+      border: '2px solid',
+      borderColor: theme.palette.common.white,
       borderRadius: '15px',
       height: '13px',
       width: '13px'

--- a/src/ui/components/Dashboard/styles.jsx
+++ b/src/ui/components/Dashboard/styles.jsx
@@ -17,6 +17,18 @@ export default makeStyles(
       fontWeight: 'bold',
       margin: '0 15px 0 15px'
     },
+    badge: {
+        backgroundColor: theme.palette.common.maroon,
+        top: '35%',
+        right: '35%',
+        border: '2px solid white',
+        borderRadius: '15px',
+        height: '13px',
+        width: '13px',
+    },
+    badgeRoot: {
+        cursor: 'pointer',
+    },
     breakLine: {
       flexGrow: 1,
       borderBottom: `1px solid ${theme.palette.common.grayMedium}`,

--- a/src/ui/components/Notifications/Notifications.jsx
+++ b/src/ui/components/Notifications/Notifications.jsx
@@ -8,6 +8,7 @@ import HistoryIcon from '@material-ui/icons/History';
 import DoneIcon from '@material-ui/icons/Done';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import useStyles from './styles';
+import moment from 'moment';
 
 const Notifications = props => {
   const classes = useStyles();
@@ -23,57 +24,6 @@ const Notifications = props => {
     };
   });
 
-  const getElapsed = time => {
-    const now = Date.now();
-    const diff = now - time;
-    const diffInSeconds = diff / 1000;
-    if (diffInSeconds >= 60) {
-      const diffInMinutes = diffInSeconds / 60;
-      if (diffInMinutes >= 60) {
-        const diffInHours = diffInMinutes / 60;
-        if (diffInHours >= 24) {
-          const diffInDays = diffInHours / 24;
-          if (diffInDays >= 365) {
-            const diffInYears = Math.floor(diffInDays / 365);
-            if (diffInYears === 1) {
-              return `${diffInYears} year ago`;
-            } else {
-              return `${diffInYears} years ago`;
-            }
-          } else {
-            const realDiff = Math.floor(diffInDays);
-            if (realDiff === 1) {
-              return `${realDiff} day ago`;
-            } else {
-              return `${realDiff} days ago`;
-            }
-          }
-        } else {
-          const realDiff = Math.floor(diffInHours);
-          if (realDiff === 1) {
-            return `${realDiff} hr ago`;
-          } else {
-            return `${realDiff} hrs ago`;
-          }
-        }
-      } else {
-        const realDiff = Math.floor(diffInMinutes);
-        if (realDiff === 1) {
-          return `${realDiff} min ago`;
-        } else {
-          return `${realDiff} mins ago`;
-        }
-      }
-    } else {
-      const realDiff = Math.floor(diffInSeconds);
-      if (realDiff === 1) {
-        return `${realDiff} second ago`;
-      } else {
-        return `${realDiff} seconds ago`;
-      }
-    }
-  };
-
   return (
     <div className={classes.collection}>
       {notifs.length > 0 ? (
@@ -86,7 +36,7 @@ const Notifications = props => {
                 <div className={classes.content}>{notif.notif.message || notif.notif}</div>
               </div>
               <HistoryIcon fontSize="large" className={classes.historyIcon} />
-              <div className={classes.timestamp}>{getElapsed(notif.timestamp)}</div>
+              <div className={classes.timestamp}>{moment(notif.timestamp).fromNow()}</div>
               <DoneIcon
                 className={classes.doneIcon}
                 fontSize="large"

--- a/src/ui/components/Notifications/Notifications.jsx
+++ b/src/ui/components/Notifications/Notifications.jsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import axios from 'axios';
+import { useQueryClient } from 'react-query';
+
+import PropTypes from 'prop-types';
+import {
+    Button,
+    Divider,
+    FormControl,
+    Input,
+    InputLabel,
+    MenuItem,
+    Paper,
+    Select,
+    Snackbar
+  } from '@material-ui/core';
+import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
+import HistoryIcon from '@material-ui/icons/History';
+import DoneIcon from '@material-ui/icons/Done';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
+import useStyles from './styles';
+import { v4 } from 'uuid';
+
+const Notifications = props => {
+  const classes = useStyles();
+  const queryClient = useQueryClient();
+
+  const { notifs } = props;
+  const updateNotif = useCallback((notif) => {
+      return () => {
+        notif.viewed = true;
+        axios.put(`/collection/notifications?id=${notif.id}`, notif).then(() => {
+            queryClient.invalidateQueries('notifications');
+        })
+      }
+  })
+
+
+
+  const getElapsed = (time) => {
+      const now = Date.now();
+      const diff = now - time;
+      const diffInSeconds = diff/1000;
+      if(diffInSeconds >= 60) {
+          const diffInMinutes = diffInSeconds/60;
+          if(diffInMinutes >= 60) {
+              const diffInHours = diffInMinutes/60;
+              if(diffInHours >= 24) {
+                  const diffInDays = diffInHours/24;
+                  if(diffInDays >= 365) {
+                      const diffInYears = Math.floor(diffInDays/365);
+                      if (diffInYears === 1) {
+                        return `${diffInYears} year ago`
+                      } else {
+                        return `${diffInYears} years ago`
+                      }
+                  } else {
+                    const realDiff = Math.floor(diffInDays); 
+                    if(realDiff === 1) {
+                        return `${realDiff} day ago`
+                    }else {
+                        return `${realDiff} days ago`
+                    }
+                  }
+              } else {
+                const realDiff = Math.floor(diffInHours); 
+                if(realDiff === 1) {
+                    return `${realDiff} hr ago`
+                }else {
+                    return `${realDiff} hrs ago`
+                }
+              }
+          } else {
+            const realDiff = Math.floor(diffInMinutes); 
+            if(realDiff === 1) {
+                return `${realDiff} min ago`
+            }else {
+                return `${realDiff} mins ago`
+            }
+          }
+      } else {
+        const realDiff = Math.floor(diffInSeconds); 
+        if(realDiff === 1) {
+            return `${realDiff} second ago`
+        }else {
+            return `${realDiff} seconds ago`
+        }
+      }
+  }
+
+
+  return (
+    <div className={classes.collection}>
+        {notifs.length > 0 ? notifs.map((notif) => {
+                return (
+                    <div className={classes.notificationCard}>
+                        <ErrorOutlineIcon fontSize="large" className={classes.errorIcon} />
+                        <div className={classes.notificationSection}>
+                            Error Recieved: 
+                        </div>
+                        <div className={`${classes.notificationSection} ${classes.notificationContent}`}>
+                            <div className={classes.content}>
+                                {notif.notif}
+                            </div>
+                        </div>
+                        <HistoryIcon fontSize='large' className={classes.historyIcon}/>
+                        <div className={classes.timestamp}>
+                            {getElapsed(notif.timestamp)}
+                        </div>
+                        <DoneIcon className={classes.doneIcon} fontSize='large' onClick={updateNotif(notif)}/>
+                        <OpenInNewIcon className={classes.openIcon} color='secondary' fontSize='large' />
+                </div>
+                )
+        }) :
+        <div className={classes.collection}>
+            <div className={classes.notificationCard}>
+                No New Notifications
+            </div>
+        </div>
+    }
+    </div>
+  );
+};
+
+Notifications.propTypes = {
+  selectedCollection: PropTypes.string
+};
+export default Notifications;

--- a/src/ui/components/Notifications/Notifications.jsx
+++ b/src/ui/components/Notifications/Notifications.jsx
@@ -1,128 +1,111 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import axios from 'axios';
 import { useQueryClient } from 'react-query';
 
 import PropTypes from 'prop-types';
-import {
-    Button,
-    Divider,
-    FormControl,
-    Input,
-    InputLabel,
-    MenuItem,
-    Paper,
-    Select,
-    Snackbar
-  } from '@material-ui/core';
 import ErrorOutlineIcon from '@material-ui/icons/ErrorOutline';
 import HistoryIcon from '@material-ui/icons/History';
 import DoneIcon from '@material-ui/icons/Done';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import useStyles from './styles';
-import { v4 } from 'uuid';
 
 const Notifications = props => {
   const classes = useStyles();
   const queryClient = useQueryClient();
 
   const { notifs } = props;
-  const updateNotif = useCallback((notif) => {
-      return () => {
-        notif.viewed = true;
-        axios.put(`/collection/notifications?id=${notif.id}`, notif).then(() => {
-            queryClient.invalidateQueries('notifications');
-        })
-      }
-  })
+  const updateNotif = useCallback(notif => {
+    return () => {
+      notif.viewed = true;
+      axios.put(`/collection/notifications?id=${notif.id}`, notif).then(() => {
+        queryClient.invalidateQueries('notifications');
+      });
+    };
+  });
 
-
-
-  const getElapsed = (time) => {
-      const now = Date.now();
-      const diff = now - time;
-      const diffInSeconds = diff/1000;
-      if(diffInSeconds >= 60) {
-          const diffInMinutes = diffInSeconds/60;
-          if(diffInMinutes >= 60) {
-              const diffInHours = diffInMinutes/60;
-              if(diffInHours >= 24) {
-                  const diffInDays = diffInHours/24;
-                  if(diffInDays >= 365) {
-                      const diffInYears = Math.floor(diffInDays/365);
-                      if (diffInYears === 1) {
-                        return `${diffInYears} year ago`
-                      } else {
-                        return `${diffInYears} years ago`
-                      }
-                  } else {
-                    const realDiff = Math.floor(diffInDays); 
-                    if(realDiff === 1) {
-                        return `${realDiff} day ago`
-                    }else {
-                        return `${realDiff} days ago`
-                    }
-                  }
-              } else {
-                const realDiff = Math.floor(diffInHours); 
-                if(realDiff === 1) {
-                    return `${realDiff} hr ago`
-                }else {
-                    return `${realDiff} hrs ago`
-                }
-              }
+  const getElapsed = time => {
+    const now = Date.now();
+    const diff = now - time;
+    const diffInSeconds = diff / 1000;
+    if (diffInSeconds >= 60) {
+      const diffInMinutes = diffInSeconds / 60;
+      if (diffInMinutes >= 60) {
+        const diffInHours = diffInMinutes / 60;
+        if (diffInHours >= 24) {
+          const diffInDays = diffInHours / 24;
+          if (diffInDays >= 365) {
+            const diffInYears = Math.floor(diffInDays / 365);
+            if (diffInYears === 1) {
+              return `${diffInYears} year ago`;
+            } else {
+              return `${diffInYears} years ago`;
+            }
           } else {
-            const realDiff = Math.floor(diffInMinutes); 
-            if(realDiff === 1) {
-                return `${realDiff} min ago`
-            }else {
-                return `${realDiff} mins ago`
+            const realDiff = Math.floor(diffInDays);
+            if (realDiff === 1) {
+              return `${realDiff} day ago`;
+            } else {
+              return `${realDiff} days ago`;
             }
           }
+        } else {
+          const realDiff = Math.floor(diffInHours);
+          if (realDiff === 1) {
+            return `${realDiff} hr ago`;
+          } else {
+            return `${realDiff} hrs ago`;
+          }
+        }
       } else {
-        const realDiff = Math.floor(diffInSeconds); 
-        if(realDiff === 1) {
-            return `${realDiff} second ago`
-        }else {
-            return `${realDiff} seconds ago`
+        const realDiff = Math.floor(diffInMinutes);
+        if (realDiff === 1) {
+          return `${realDiff} min ago`;
+        } else {
+          return `${realDiff} mins ago`;
         }
       }
-  }
-
+    } else {
+      const realDiff = Math.floor(diffInSeconds);
+      if (realDiff === 1) {
+        return `${realDiff} second ago`;
+      } else {
+        return `${realDiff} seconds ago`;
+      }
+    }
+  };
 
   return (
     <div className={classes.collection}>
-        {notifs.length > 0 ? notifs.map((notif) => {
-                return (
-                    <div className={classes.notificationCard}>
-                        <ErrorOutlineIcon fontSize="large" className={classes.errorIcon} />
-                        <div className={classes.notificationSection}>
-                            Error Recieved: 
-                        </div>
-                        <div className={`${classes.notificationSection} ${classes.notificationContent}`}>
-                            <div className={classes.content}>
-                                {notif.notif}
-                            </div>
-                        </div>
-                        <HistoryIcon fontSize='large' className={classes.historyIcon}/>
-                        <div className={classes.timestamp}>
-                            {getElapsed(notif.timestamp)}
-                        </div>
-                        <DoneIcon className={classes.doneIcon} fontSize='large' onClick={updateNotif(notif)}/>
-                        <OpenInNewIcon className={classes.openIcon} color='secondary' fontSize='large' />
-                </div>
-                )
-        }) :
-        <div className={classes.collection}>
-            <div className={classes.notificationCard}>
-                No New Notifications
+      {notifs.length > 0 ? (
+        notifs.map(notif => {
+          return (
+            <div key={notif.id} className={classes.notificationCard}>
+              <ErrorOutlineIcon fontSize="large" className={classes.errorIcon} />
+              <div className={classes.notificationSection}>Error Recieved:</div>
+              <div className={`${classes.notificationSection} ${classes.notificationContent}`}>
+                <div className={classes.content}>{notif.notif}</div>
+              </div>
+              <HistoryIcon fontSize="large" className={classes.historyIcon} />
+              <div className={classes.timestamp}>{getElapsed(notif.timestamp)}</div>
+              <DoneIcon
+                className={classes.doneIcon}
+                fontSize="large"
+                onClick={updateNotif(notif)}
+              />
+              <OpenInNewIcon className={classes.openIcon} color="secondary" fontSize="large" />
             </div>
+          );
+        })
+      ) : (
+        <div className={classes.collection}>
+          <div className={classes.notificationCard}>No New Notifications</div>
         </div>
-    }
+      )}
     </div>
   );
 };
 
 Notifications.propTypes = {
-  selectedCollection: PropTypes.string
+  notifs: PropTypes.array
 };
 export default Notifications;

--- a/src/ui/components/Notifications/Notifications.jsx
+++ b/src/ui/components/Notifications/Notifications.jsx
@@ -83,7 +83,7 @@ const Notifications = props => {
               <ErrorOutlineIcon fontSize="large" className={classes.errorIcon} />
               <div className={classes.notificationSection}>Error Recieved:</div>
               <div className={`${classes.notificationSection} ${classes.notificationContent}`}>
-                <div className={classes.content}>{notif.notif}</div>
+                <div className={classes.content}>{notif.notif.message || notif.notif}</div>
               </div>
               <HistoryIcon fontSize="large" className={classes.historyIcon} />
               <div className={classes.timestamp}>{getElapsed(notif.timestamp)}</div>

--- a/src/ui/components/Notifications/index.js
+++ b/src/ui/components/Notifications/index.js
@@ -1,0 +1,1 @@
+export { default } from './Notifications';

--- a/src/ui/components/Notifications/styles.jsx
+++ b/src/ui/components/Notifications/styles.jsx
@@ -1,0 +1,69 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    collection: {
+      color: 'red',
+    },
+    content: {
+        float: 'left',
+        padding: '5px 10px',
+        backgroundColor: theme.palette.common.redLight,
+        fontSize: '14px',
+        fontFamily: 'monospace',
+        fontWeight: '600'
+
+    },
+    doneIcon: {
+        padding: '5px',
+        color: theme.palette.common.grayLighter,
+        cursor: 'pointer',
+        fontSize: '50px',
+
+    },
+    openIcon: {
+        cursor: 'pointer',
+    },
+    errorIcon: {
+        color: theme.palette.common.maroon,
+        padding: '5px',
+    },
+    historyIcon: {
+        fontSize: '40px',
+        padding: '5px',
+    },
+    timestamp: {
+        fontSize: '17px',
+        flexGrow: '.15',
+        width: 0,
+        textAlign: 'left',
+        paddingLeft: '5px',
+        fontWeight: 100,
+    },
+    notificationCard: {
+        margin: '25px 35px',
+        backgroundColor: theme.palette.common.white,
+        height: '115px',
+        boxShadow: '0 4px 4px rgba(0, 0, 0, 0.10)',
+        display: 'flex',
+        alignItems: 'center',
+        paddingLeft: '15px',
+        fontSize: '18px',
+        color: theme.palette.common.grayDark
+
+    },
+    notificationSection: {
+        padding: '5px',
+    },
+    notificationContent: {
+        flexGrow: '.8',
+        width: 0,
+        justifyContent:'left',
+    },
+    spacer: {
+        flexGrow: '.2'
+    },
+
+  }),
+
+  { name: 'Notifications', index: 1 }
+);

--- a/src/ui/components/Notifications/styles.jsx
+++ b/src/ui/components/Notifications/styles.jsx
@@ -30,7 +30,7 @@ export default makeStyles(
       padding: '5px'
     },
     timestamp: {
-      fontSize: '17px',
+      fontSize: '16px',
       flexGrow: '.15',
       width: 0,
       textAlign: 'left',

--- a/src/ui/components/Notifications/styles.jsx
+++ b/src/ui/components/Notifications/styles.jsx
@@ -2,67 +2,63 @@ import { makeStyles } from '@material-ui/core/styles';
 export default makeStyles(
   theme => ({
     collection: {
-      color: 'red',
+      color: 'red'
     },
     content: {
-        float: 'left',
-        padding: '5px 10px',
-        backgroundColor: theme.palette.common.redLight,
-        fontSize: '14px',
-        fontFamily: 'monospace',
-        fontWeight: '600'
-
+      float: 'left',
+      padding: '5px 10px',
+      backgroundColor: theme.palette.common.redLight,
+      fontSize: '14px',
+      fontFamily: 'monospace',
+      fontWeight: '600'
     },
     doneIcon: {
-        padding: '5px',
-        color: theme.palette.common.grayLighter,
-        cursor: 'pointer',
-        fontSize: '50px',
-
+      padding: '5px',
+      color: theme.palette.common.grayLighter,
+      cursor: 'pointer',
+      fontSize: '50px'
     },
     openIcon: {
-        cursor: 'pointer',
+      cursor: 'pointer'
     },
     errorIcon: {
-        color: theme.palette.common.maroon,
-        padding: '5px',
+      color: theme.palette.common.maroon,
+      padding: '5px'
     },
     historyIcon: {
-        fontSize: '40px',
-        padding: '5px',
+      fontSize: '40px',
+      padding: '5px'
     },
     timestamp: {
-        fontSize: '17px',
-        flexGrow: '.15',
-        width: 0,
-        textAlign: 'left',
-        paddingLeft: '5px',
-        fontWeight: 100,
+      fontSize: '17px',
+      flexGrow: '.15',
+      width: 0,
+      textAlign: 'left',
+      paddingLeft: '5px',
+      fontWeight: 100
     },
     notificationCard: {
-        margin: '25px 35px',
-        backgroundColor: theme.palette.common.white,
-        height: '115px',
-        boxShadow: '0 4px 4px rgba(0, 0, 0, 0.10)',
-        display: 'flex',
-        alignItems: 'center',
-        paddingLeft: '15px',
-        fontSize: '18px',
-        color: theme.palette.common.grayDark
-
+      margin: '25px 35px',
+      backgroundColor: theme.palette.common.white,
+      height: '115px',
+      boxShadow: '0 4px 4px rgba(0, 0, 0, 0.10)',
+      display: 'flex',
+      alignItems: 'center',
+      paddingLeft: '15px',
+      fontSize: '18px',
+      color: theme.palette.common.grayDark
     },
     notificationSection: {
-        padding: '5px',
+      padding: '5px'
     },
     notificationContent: {
-        flexGrow: '.8',
-        width: 0,
-        justifyContent:'left',
+      flexGrow: '.8',
+      width: 0,
+      justifyContent: 'left'
     },
     spacer: {
-        flexGrow: '.2'
-    },
-
+      flexGrow: '.2'
+    }
   }),
 
   { name: 'Notifications', index: 1 }

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -22,7 +22,7 @@ const colors = {
   maroon: '#a83048',
   purple: '#8b72d6',
   turqoise: '#37c0ae',
-  turqoiseLight: '#e6f7f5',
+  turqoiseLight: '#e6f7f5'
 };
 
 const paletteBase = {

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -4,6 +4,7 @@ const colors = {
   black: '#222',
   red: '#d95d77',
   redDark: '#bb3551',
+  redLight: '#ffeded',
   blue: '#5d89a1',
   blueDark: '#386883',
   blueLighter: '#9ad2f0',
@@ -11,16 +12,17 @@ const colors = {
   grayMedium: '#676a70',
   grayBlue: '#cbd5df',
   grayBlueDark: '#7d8892',
+  grayHighlight: '#eaeaeb',
   grayLight: '#4e5258',
   grayLighter: '#b5b6ba',
   grayLightest: '#eaeef2',
   grayDark: '#444',
   grayVeryDark: '#3a3a3a',
   green: '#2fa874',
+  maroon: '#a83048',
   purple: '#8b72d6',
   turqoise: '#37c0ae',
   turqoiseLight: '#e6f7f5',
-  grayHighlight: '#eaeaeb'
 };
 
 const paletteBase = {


### PR DESCRIPTION
Adds the UI for the notification tab, functionality for the notification bell icon, and a new collection to the database specifically for notifications under the assumption that future notifications won't all exclusively be errors.  The notification data structure should also include the userId if it can, but I've left that out for now to simplify things.

To test the UI, you can either trigger an error (that reports using the `error()` log function) or you can just visit `/index`, since I've added some testing code to create an error when visiting the test endpoint.  This should trigger the backend UI to display the new notification, which can be dismissed by pressing on the grey checkmark.  