### PR TITLE
Small Fixes for Running on AWS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "3000:3000"
     environment:
+      - DEBUG=medmorph-backend:*
+      - ADMIN_TOKEN=admin
       - AUTH_CERTS_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protocol/openid-connect/certs
       - AUTH_TOKEN_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protocol/openid-connect/token
       - BASE_URL=http://localhost:3000

--- a/docker/aws-docker-compose.yml
+++ b/docker/aws-docker-compose.yml
@@ -8,6 +8,8 @@ services:
     ports:
       - "3000:3000"
     environment:
+      - DEBUG=medmorph-backend:*
+      - ADMIN_TOKEN=admin
       - AUTH_CERTS_URL=http://ec2-3-211-58-180.compute-1.amazonaws.com:8090/auth/realms/backend_app/protocol/openid-connect/certs
       - AUTH_TOKEN_URL=http://ec2-3-211-58-180.compute-1.amazonaws.com:8090/auth/realms/backend_app/protocol/openid-connect/token
       - BASE_URL=http://ec2-3-211-58-180.compute-1.amazonaws.com:3000

--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -96,7 +96,8 @@ const Collections = props => {
           { value: 'name', label: 'name', edit: true },
           { value: 'id', label: 'id', edit: false },
           { value: 'endpoint', label: 'endpoint', edit: true },
-          { value: 'type', label: 'type', edit: false }
+          { value: 'type', label: 'type', edit: false },
+          { value: 'clientId', label: 'clientId', edit: true }
         ];
         return {
           headers,

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -102,9 +102,8 @@ const baseIgActions = {
         }
       )
       .catch(err => {
-        error(
-          `Error submitting Bundle/${context.reportingBundle.id} to ${context.client.dest}\n${err.message}`
-        );
+        const bundleId = context.reportingBundle.id;
+        error(`Error submitting Bundle/${bundleId} to ${context.client.dest}\n${err.message}`);
         context.flags['submitted'] = false;
       });
   },

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -102,7 +102,9 @@ const baseIgActions = {
         }
       )
       .catch(err => {
-        error(err);
+        error(
+          `Error submitting Bundle/${context.reportingBundle.id} to ${context.client.dest}\n${err.message}`
+        );
         context.flags['submitted'] = false;
       });
   },
@@ -118,7 +120,7 @@ const baseIgActions = {
         }
       )
       .catch(err => {
-        error(err);
+        error(`Error deidentifying Bundle/${context.reportingBundle.id}\n${err.message}`);
         context.flags['deidentified'] = false;
       });
   },
@@ -134,7 +136,7 @@ const baseIgActions = {
         }
       )
       .catch(err => {
-        error(err);
+        error(`Error anonymizing Bundle/${context.reportingBundle.id}\n${err.message}`);
         context.flags['anonymized'] = false;
       });
   },
@@ -150,7 +152,7 @@ const baseIgActions = {
         }
       )
       .catch(err => {
-        error(err);
+        error(`Error pseudonymizing Bundle/${context.reportingBundle.id}\n${err.message}`);
         context.flags['pseudonymized'] = false;
       });
   },

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -20,7 +20,7 @@ async function connectToServer(url) {
   const jwt = await generateJWT(clientId, tokenEndpoint);
 
   const props = {
-    scope: 'system/*.read',
+    scope: 'system/*.*',
     grant_type: 'client_credentials',
     client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
     client_assertion: jwt

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -39,7 +39,7 @@ async function connectToServer(url) {
   const data = await axios
     .post(tokenEndpoint, queryString.stringify(props), headers)
     .then(response => response.data)
-    .catch(err => error(err));
+    .catch(err => error(`Error obtaining access token from ${tokenEndpoint}\n${err.message}`));
   return data;
 }
 
@@ -60,7 +60,7 @@ async function getAccessToken(url) {
       return token.access_token;
     } catch (e) {
       servers.clearAccessToken(server);
-      error(e);
+      error(`Exception obtaining an access token from ${server.endpoint}\n${e.message}`);
       throw e;
     }
   } else {

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -326,9 +326,12 @@ function postSubscriptionsToEHR(subscriptions) {
       const ehrToken = await getAccessToken(ehrServer.endpoint);
       const headers = { Authorization: `Bearer ${ehrToken}` };
       axios
-        .put(`${ehrServer.endpoint}/Subscription/${subscriptionId}`, subscription, { headers })
+        .put(fullUrl, subscription, { headers })
         .then(() =>
           debug(`Subscription with id ${subscriptionId} created/updated on ${ehrServer.endpoint}`)
+        )
+        .catch(err =>
+          error(`Error posting Subscription/${subscriptionId} to EHR.\n${err.message}`)
         );
     }
   });

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -61,7 +61,7 @@ async function getResources(server, resourceType) {
   const axiosResponse = axios
     .get(url, { headers: headers })
     .then(response => response.data)
-    .catch(err => error(err));
+    .catch(err => error(`Error getting ${url}\n${err.message}`));
   return axiosResponse.then(data => {
     debug(`Fetched ${server}/${data.resourceType}/${data.id}`);
     if (!data.entry) return;
@@ -93,7 +93,7 @@ async function getResourceById(server, resourceType, id) {
   const axiosResponse = axios
     .get(url, { headers: headers })
     .then(response => response.data)
-    .catch(err => error(err));
+    .catch(err => error(`Error getting ${url}\n${err.message}`));
   return axiosResponse.then(resource => {
     if (!resource) return;
     debug(`Fetched ${server}/${resource.resourceType}/${resource.id}`);
@@ -413,10 +413,11 @@ async function getReferencedResource(url, reference) {
     const [resourceType, id] = reference.split('/');
     const token = await getAccessToken(url);
     const headers = { Authorization: `Bearer ${token}` };
+    const requestUrl = `${url}/${resourceType}/${id}`;
     const resource = await axios
-      .get(`${url}/${resourceType}/${id}`, { headers: headers })
+      .get(requestUrl, { headers: headers })
       .then(response => response.data)
-      .catch(err => error(err));
+      .catch(err => error(`Error getting referenced resource ${requestUrl}\n${err.message}`));
     if (resource) {
       debug(`Retrieved reference resource ${resource.resourceType}/${resource.id} from ${url}`);
       return resource.data;


### PR DESCRIPTION
Three fixes to get it working on AWS:
1. Include the clientId for servers in the UI. If this field is not included when creating the server the authorization will fail. I know we are removing auth for the connectathon but this won't break anything without auth (it will just be extra info there which means nothing).
2. Update the docker-compose files to include the DEBUG and ADMIN_TOKEN environment variables
3. Ensures errors are logged with a helpful message and id