### PR TITLE
login page ui

### DIFF
--- a/src/ui/.eslintrc.json
+++ b/src/ui/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "env": {
+      "browser": true
+    }
+  }
+  

--- a/src/ui/components/Admin/Admin.jsx
+++ b/src/ui/components/Admin/Admin.jsx
@@ -10,14 +10,14 @@ const Admin = () => {
 
   return (
     <>
-      {!isAuthorized && <Login />}
-      {isAuthorized && (
-        <div>
-          <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
+        {!isAuthorized && <Login />}
+        {isAuthorized && (
+          <div>
             <DashboardLayout />
-          </ThemeProvider>
-        </div>
-      )}
+          </div>
+        )}
+      </ThemeProvider>
     </>
   );
 };

--- a/src/ui/components/Auth/Login.jsx
+++ b/src/ui/components/Auth/Login.jsx
@@ -1,26 +1,47 @@
-import './auth.css';
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, { memo, useCallback, useState, useEffect } from 'react';
 import { TextField, Button, Snackbar } from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 import axios from 'axios';
 import { useQueryClient } from 'react-query';
+import useStyles from './styles';
 
 const Login = () => {
   const queryClient = useQueryClient();
-  const emailTextField = useRef();
-  const passwordTextField = useRef();
+  const classes = useStyles();
   const [message, setMessage] = useState(null);
-
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
   const handleClose = useCallback(() => setMessage(null));
 
+  useEffect(() => {
+    const listener = event => {
+      if (event.code === 'Enter' || event.code === 'NumpadEnter') {
+        event.preventDefault();
+        onSubmit();
+      }
+    };
+    document.addEventListener('keydown', listener);
+    return () => {
+      document.removeEventListener('keydown', listener);
+    };
+  }, [username, password]);
+
+  const _setUsername = event => {
+    setUsername(event.target.value);
+  };
+
+  const _setPassword = event => {
+    setPassword(event.target.value);
+  };
+
   const onSubmit = useCallback(() => {
-    if (emailTextField.current?.value && passwordTextField.current?.value) {
+    if (username && password) {
       axios
         .post(
           `/auth/login`,
           {
-            email: emailTextField.current.value,
-            password: passwordTextField.current.value
+            email: username,
+            password: password
           },
           { withCredentials: true }
         )
@@ -32,10 +53,10 @@ const Login = () => {
           console.error(err);
         });
     }
-  }, [queryClient]);
+  }, [queryClient, username, password]);
 
   return (
-    <div className={'login-container'}>
+    <div className={classes.background}>
       <Snackbar
         open={message !== null}
         autoHideDuration={6000}
@@ -46,25 +67,68 @@ const Login = () => {
           {message}
         </Alert>
       </Snackbar>
-      <h2>Login</h2>
-      <TextField
-        id="email-text-field"
-        inputRef={emailTextField}
-        variant="outlined"
-        label="email"
-        className={'form-row'}
-      />
-      <TextField
-        id="password-text-field"
-        inputRef={passwordTextField}
-        variant="outlined"
-        type="password"
-        label="password"
-        className={'form-row'}
-      />
-      <Button variant="contained" color="primary" onClick={onSubmit} className={'form-row'}>
-        Login
-      </Button>
+      <div className={classes.adminBar}>
+        <span className={classes.adminBarText}>
+          <strong>MedMorph</strong> Admin Console
+        </span>
+      </div>
+      <div className={classes.loginContent}>
+        <div className={classes.loginHeader}>Log in.</div>
+        <div className={classes.loginSubheader}>Log in to view your admin console.</div>
+        <form noValidate autoComplete="off">
+          <TextField
+            classes={{
+              root: classes.loginInput
+            }}
+            InputProps={{
+              classes: {
+                input: classes.resize
+              }
+            }}
+            InputLabelProps={{
+              classes: {
+                root: classes.resize
+              }
+            }}
+            value={username}
+            onChange={_setUsername}
+            label="Username"
+          />
+          <TextField
+            classes={{
+              root: `${classes.passwordField} ${classes.loginInput}`
+            }}
+            InputProps={{
+              classes: {
+                input: classes.resize
+              }
+            }}
+            InputLabelProps={{
+              classes: {
+                root: classes.resize
+              }
+            }}
+            type="password"
+            label="Password"
+            value={password}
+            onChange={_setPassword}
+          />
+          <div className={classes.loginPersistance}>
+            <input type="checkbox" className={classes.loginCheckbox} />
+            <span className={classes.loginCheckboxText}>Keep me logged in</span>
+          </div>
+          <Button
+            variant="contained"
+            color="secondary"
+            disableElevation
+            classes={{ root: classes.loginButton }}
+            onClick={onSubmit}
+          >
+            Log In
+          </Button>
+          <div className={classes.passwordForget}>Forgot password?</div>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/ui/components/Auth/Login.jsx
+++ b/src/ui/components/Auth/Login.jsx
@@ -9,8 +9,8 @@ const Login = () => {
   const queryClient = useQueryClient();
   const classes = useStyles();
   const [message, setMessage] = useState(null);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
+  const [username, _setUsername] = useState('');
+  const [password, _setPassword] = useState('');
   const handleClose = useCallback(() => setMessage(null));
 
   useEffect(() => {
@@ -26,13 +26,13 @@ const Login = () => {
     };
   }, [username, password]);
 
-  const _setUsername = event => {
-    setUsername(event.target.value);
-  };
+  const setUsername = useCallback(event => {
+    _setUsername(event.target.value);
+  });
 
-  const _setPassword = event => {
-    setPassword(event.target.value);
-  };
+  const setPassword = useCallback(event => {
+    _setPassword(event.target.value);
+  });
 
   const onSubmit = useCallback(() => {
     if (username && password) {
@@ -72,10 +72,10 @@ const Login = () => {
           <strong>MedMorph</strong> Admin Console
         </span>
       </div>
-      <div className={classes.loginContent}>
+      <div className={`${classes.loginContent} ${classes.formFont}`}>
         <div className={classes.loginHeader}>Log in.</div>
         <div className={classes.loginSubheader}>Log in to view your admin console.</div>
-        <form noValidate autoComplete="off">
+        <form noValidate autoComplete="off" className={classes.formFont}>
           <TextField
             classes={{
               root: classes.loginInput
@@ -91,7 +91,7 @@ const Login = () => {
               }
             }}
             value={username}
-            onChange={_setUsername}
+            onChange={setUsername}
             label="Username"
           />
           <TextField
@@ -111,9 +111,9 @@ const Login = () => {
             type="password"
             label="Password"
             value={password}
-            onChange={_setPassword}
+            onChange={setPassword}
           />
-          <div className={classes.loginPersistance}>
+          <div className={`${classes.loginPersistance} ${classes.formFont}`}>
             <input type="checkbox" className={classes.loginCheckbox} />
             <span className={classes.loginCheckboxText}>Keep me logged in</span>
           </div>
@@ -121,7 +121,7 @@ const Login = () => {
             variant="contained"
             color="secondary"
             disableElevation
-            classes={{ root: classes.loginButton }}
+            classes={{ root: classes.loginButton, label: classes.formFont }}
             onClick={onSubmit}
           >
             Log In

--- a/src/ui/components/Auth/auth.css
+++ b/src/ui/components/Auth/auth.css
@@ -1,9 +1,0 @@
-.login-container {
-    width: 80%;
-    margin: auto;
-}
-
-.form-row {
-    width: 100%;
-    margin-top: 10px !important;
-}

--- a/src/ui/components/Auth/styles.jsx
+++ b/src/ui/components/Auth/styles.jsx
@@ -3,7 +3,7 @@ export default makeStyles(
   theme => ({
     adminBar: {
       height: '95px',
-      backgroundColor: '#8b72d6',
+      backgroundColor: theme.palette.common.purple,
       width: '100%',
       textAlign: 'center',
       lineHeight: '95px'
@@ -16,8 +16,11 @@ export default makeStyles(
       marginLeft: '20px'
     },
     background: {
-      backgroundColor: '#f3f3f9',
+      backgroundColor: theme.palette.common.offWhite,
       height: '100vh'
+    },
+    formFont: {
+        fontFamily: '"Gill Sans", sans-serif',
     },
     loginButton: {
       width: '460px',
@@ -25,7 +28,7 @@ export default makeStyles(
       color: theme.palette.common.white,
       fontSize: '32px',
       textTransform: 'none',
-      fontFamily: '"Gill Sans", sans-serif',
+      fontFamily: 'inherit',
       fontWeight: 200
     },
     loginContent: {
@@ -36,7 +39,6 @@ export default makeStyles(
       margin: '40px auto',
       paddingLeft: '75px',
       paddingTop: '90px',
-      fontFamily: '"Gill Sans", sans-serif',
       textAlign: 'left'
     },
     loginHeader: {
@@ -60,7 +62,7 @@ export default makeStyles(
       margin: '60px 0px 15px 0px'
     },
     loginCheckboxText: {
-      fontWeight: 200,
+      fontWeight: 100,
       fontSize: '24px',
       marginLeft: '20px',
       color: theme.palette.common.grayLightText,

--- a/src/ui/components/Auth/styles.jsx
+++ b/src/ui/components/Auth/styles.jsx
@@ -1,0 +1,100 @@
+import { makeStyles } from '@material-ui/core/styles';
+export default makeStyles(
+  theme => ({
+    adminBar: {
+      height: '95px',
+      backgroundColor: '#8b72d6',
+      width: '100%',
+      textAlign: 'center',
+      lineHeight: '95px'
+    },
+    adminBarText: {
+      color: theme.palette.common.white,
+      fontSize: '19px',
+      fontFamily: 'Verdana',
+      float: 'left',
+      marginLeft: '20px'
+    },
+    background: {
+      backgroundColor: '#f3f3f9',
+      height: '100vh'
+    },
+    loginButton: {
+      width: '460px',
+      height: '90px',
+      color: theme.palette.common.white,
+      fontSize: '32px',
+      textTransform: 'none',
+      fontFamily: '"Gill Sans", sans-serif',
+      fontWeight: 200
+    },
+    loginContent: {
+      width: '600px',
+      height: '700px',
+      boxShadow: '0 4px 4px rgba(0, 0, 0, 0.10)',
+      backgroundColor: theme.palette.common.white,
+      margin: '40px auto',
+      paddingLeft: '75px',
+      paddingTop: '90px',
+      fontFamily: '"Gill Sans", sans-serif',
+      textAlign: 'left'
+    },
+    loginHeader: {
+      fontSize: '36px',
+      fontWeight: 600,
+      width: '100%',
+      color: theme.palette.common.grayDark,
+      fontFamily: 'inherit'
+    },
+    loginInput: {
+      display: 'block',
+      fontFamily: 'inherit'
+    },
+    loginPersistance: {
+      display: 'flex',
+      lineHeight: '144px'
+    },
+    loginCheckbox: {
+      height: '24px',
+      width: '24px',
+      margin: '60px 0px 15px 0px'
+    },
+    loginCheckboxText: {
+      fontWeight: 200,
+      fontSize: '24px',
+      marginLeft: '20px',
+      color: theme.palette.common.grayLightText,
+      fontFamily: 'inherit'
+    },
+    loginSubheader: {
+      fontSize: '24px',
+      textAlign: 'left',
+      fontWeight: 100,
+      color: theme.palette.common.grayLightText,
+      marginTop: '20px',
+      fontFamily: 'inherit'
+    },
+    passwordField: {
+      marginTop: '30px'
+    },
+    passwordForget: {
+      float: 'right',
+      color: theme.palette.secondary.main,
+      margin: '10px 70px 0px 0px',
+      fontSize: '24px',
+      fontFamily: 'inherit',
+      cursor: 'pointer'
+    },
+    resize: {
+      display: 'block',
+      marginTop: '30px',
+      marginBottom: '5px',
+      fontSize: '20px',
+      fontWeight: 100,
+      color: theme.palette.common.grayLightText,
+      width: '450px'
+    }
+  }),
+
+  { name: 'Auth', index: 1 }
+);

--- a/src/ui/components/Auth/styles.jsx
+++ b/src/ui/components/Auth/styles.jsx
@@ -20,7 +20,7 @@ export default makeStyles(
       height: '100vh'
     },
     formFont: {
-        fontFamily: '"Gill Sans", sans-serif',
+      fontFamily: '"Gill Sans", sans-serif'
     },
     loginButton: {
       width: '460px',

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -1,6 +1,7 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 const colors = {
   white: '#fff',
+  offWhite: '#f5f5fa',
   black: '#222',
   red: '#d95d77',
   redDark: '#bb3551',

--- a/src/ui/components/styles/theme.jsx
+++ b/src/ui/components/styles/theme.jsx
@@ -18,6 +18,7 @@ const colors = {
   grayLightest: '#eaeef2',
   grayDark: '#444',
   grayVeryDark: '#3a3a3a',
+  grayLightText: '#87878e',
   green: '#2fa874',
   maroon: '#a83048',
   purple: '#8b72d6',


### PR DESCRIPTION
changes the login page to have a simple UI.  The forget password and keep my logged in options don't do anything for now.  But you can press enter to log in after putting in credentials now.

In order to get the linter to work, I had to add an extra `eslintrc` file so that the UI files would allows global browser variables like `document`.  

You can test the changes by running the app and going to the home page to log in.  