### PR TITLE
Fixes based on sandbox testing

### DIFF
--- a/src/ui/components/Collections/Collections.jsx
+++ b/src/ui/components/Collections/Collections.jsx
@@ -97,7 +97,12 @@ const Collections = props => {
           { value: 'id', label: 'id', edit: false },
           { value: 'endpoint', label: 'endpoint', edit: true },
           { value: 'type', label: 'type', edit: false },
-          { value: 'clientId', label: 'clientId', edit: true }
+          { value: 'clientId', label: 'clientId', edit: true },
+          { value: 'secret', label: 'secret', edit: true },
+          // NOTE: secret is only used for client_secret_basic auth.
+          // see src/utils/client.js : connectToServer for more info
+          { value: 'customScopes', label: 'customScopes', edit: true },
+          { value: 'type', label: 'type', edit: false }
         ];
         return {
           headers,

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -36,6 +36,10 @@ async function connectToServer(url) {
     }
   };
 
+  // NOTE: client_secret_basic authorization is not part of the backend auth spec
+  // (which requires the use of the signed authentication JWT)
+  // but it is included here to enable connecting to the Cerner sandbox,
+  // which currently only supports the client_secret_basic auth type
   if (secret) {
     delete props.client_assertion_type;
     delete props.client_assertion;
@@ -45,6 +49,7 @@ async function connectToServer(url) {
 
     headers.headers['Authorization'] = `Basic ${base64}`;
   }
+  // end client_secret_basic logic
 
   // Get access token from auth server
   const data = await axios

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -89,7 +89,7 @@ async function getTokenEndpoint(url) {
   try {
     const response = await axios.get(`${url}/.well-known/smart-configuration`);
     return response.data.token_endpoint;
-  } catch (e) {
+  } catch (ex) {
     try {
       // sometimes the smart-config is in a non-standard place,
       // so let's try the server capability statement
@@ -102,11 +102,11 @@ async function getTokenEndpoint(url) {
         e => e.url === 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris'
       );
       return oauth.extension.find(e => e.url === 'token').valueUri;
-    } catch (e2) {
+    } catch (ex2) {
       // not sure what to do if both fail?
-      error(e);
-      error(e2);
-      throw e2;
+      error(ex);
+      error(ex2);
+      throw ex2;
     }
   }
 }

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -324,7 +324,7 @@ function postSubscriptionsToEHR(subscriptions) {
 
       // Create/Update Subscriptions on EHR server
       const ehrToken = await getAccessToken(ehrServer.endpoint);
-      const headers = { 
+      const headers = {
         Authorization: `Bearer ${ehrToken}`,
         'Content-Type': 'application/fhir+json'
       };

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -324,7 +324,10 @@ function postSubscriptionsToEHR(subscriptions) {
 
       // Create/Update Subscriptions on EHR server
       const ehrToken = await getAccessToken(ehrServer.endpoint);
-      const headers = { Authorization: `Bearer ${ehrToken}` };
+      const headers = { 
+        Authorization: `Bearer ${ehrToken}`,
+        'Content-Type': 'application/fhir+json'
+      };
       axios
         .put(fullUrl, subscription, { headers })
         .then(() =>


### PR DESCRIPTION
This PR brings in a few fixes based on testing against the Epic and Cerner sandboxes:

- Cerner doesn't support wildcard scopes, so now we can configure a custom set of scopes to use per server
- Cerner uses the `client_secret_basic` method of authentication which uses a client_secret instead of a JWT
- Epic's smart-configuration isn't at `{baseUrl}/.well-known/smart-configuration` so if getting that URL fails, we can try to get the token endpoint via the server metadata
- Posting Subscriptions to the subscription-proxy fails if we don't specify the content-type