### PR TITLE
Add env variables to remove auth

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -5,3 +5,5 @@ AUTH_TOKEN_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protoc
 DATA_TRUST_SERVICE=http://localhost:3005
 BASE_URL=http://localhost:3000
 ADMIN_TOKEN=admin
+REQUIRE_AUTH=false
+REQUIRE_AUTH_FOR_OUTGOING=false

--- a/.env.dev
+++ b/.env.dev
@@ -5,5 +5,5 @@ AUTH_TOKEN_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protoc
 DATA_TRUST_SERVICE=http://localhost:3005
 BASE_URL=http://localhost:3000
 ADMIN_TOKEN=admin
-REQUIRE_AUTH=false
-REQUIRE_AUTH_FOR_OUTGOING=false
+REQUIRE_AUTH=true
+REQUIRE_AUTH_FOR_OUTGOING=true

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Certain configuration properties MUST be set via enviornment variables. The easi
 | DATA_TRUST_SERVICE | Yes | The base url for the data/trust service server. |
 | BASE_URL | Yes | The base url for this server. |
 | ADMIN_TOKEN | No | The value of the admin token to bypass authorization. If unset no admin token can be used. |
+| AUTH | No | If false or unset, an access token is not required to make requests.
+| AUTH_REQUIRED_FOR_OUTGOING | No | If false or unset, the backend app will not acquire an access token before sending requests to other servers.
 
 ```env
 # Port number for the server, defaults to 3000 if not provided

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Certain configuration properties MUST be set via enviornment variables. The easi
 | DATA_TRUST_SERVICE | Yes | The base url for the data/trust service server. |
 | BASE_URL | Yes | The base url for this server. |
 | ADMIN_TOKEN | No | The value of the admin token to bypass authorization. If unset no admin token can be used. |
-| AUTH | No | If false or unset, an access token is not required to make requests.
-| AUTH_REQUIRED_FOR_OUTGOING | No | If false or unset, the backend app will not acquire an access token before sending requests to other servers.
+| AUTH | No | If false, an access token will not be required to make requests. Defaults to true if unset. |
+| AUTH_REQUIRED_FOR_OUTGOING | No | If false, the backend app will not acquire an access token before sending requests to other servers. Defaults to true if unset. |
 
 ```env
 # Port number for the server, defaults to 3000 if not provided

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,5 @@ services:
       - AUTH_TOKEN_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protocol/openid-connect/token
       - BASE_URL=http://localhost:3000
       - DATA_TRUST_SERVICE=http://localhost:3005
+      - REQUIRE_AUTH=true
+      - REQUIRE_AUTH_FOR_OUTGOING=true

--- a/docker/aws-docker-compose.yml
+++ b/docker/aws-docker-compose.yml
@@ -14,3 +14,5 @@ services:
       - AUTH_TOKEN_URL=http://ec2-3-211-58-180.compute-1.amazonaws.com:8090/auth/realms/backend_app/protocol/openid-connect/token
       - BASE_URL=http://ec2-3-211-58-180.compute-1.amazonaws.com:3000
       - DATA_TRUST_SERVICE=http://ec2-3-211-58-180.compute-1.amazonaws.com:3001
+      - REQUIRE_AUTH=true
+      - REQUIRE_AUTH_FOR_OUTGOING=true

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -30,7 +30,7 @@ function generateToken(id) {
  * Middleware for verifying the access token on a Subscription notification
  */
 function subscriptionAuthorization(req, res, next) {
-  if (!process.env.REQUIRE_AUTH || process.env.REQUIRE_AUTH === 'false') return next();
+  if (process.env.REQUIRE_AUTH && process.env.REQUIRE_AUTH === 'false') return next();
 
   const token = getToken(req);
   const adminToken = process.env.ADMIN_TOKEN;
@@ -84,7 +84,7 @@ function checkScopes(req, res, next, jwtPayload) {
  * be accessible via both authentication schemes.
  */
 function userOrBackendAuthorization(req, res, next) {
-  if (!process.env.REQUIRE_AUTH || process.env.REQUIRE_AUTH === 'false') return next();
+  if (process.env.REQUIRE_AUTH && process.env.REQUIRE_AUTH === 'false') return next();
 
   const token = getToken(req);
   const adminToken = process.env.ADMIN_TOKEN;

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -30,6 +30,8 @@ function generateToken(id) {
  * Middleware for verifying the access token on a Subscription notification
  */
 function subscriptionAuthorization(req, res, next) {
+  if (!process.env.REQUIRE_AUTH || process.env.REQUIRE_AUTH === 'false') return next();
+
   const token = getToken(req);
   const adminToken = process.env.ADMIN_TOKEN;
   if (adminToken && token === adminToken) return next();
@@ -82,6 +84,8 @@ function checkScopes(req, res, next, jwtPayload) {
  * be accessible via both authentication schemes.
  */
 function userOrBackendAuthorization(req, res, next) {
+  if (!process.env.REQUIRE_AUTH || process.env.REQUIRE_AUTH === 'false') return next();
+
   const token = getToken(req);
   const adminToken = process.env.ADMIN_TOKEN;
   if (req.isAuthenticated()) return next();

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -65,6 +65,9 @@ async function connectToServer(url) {
  * @param {string} url - the base url of the server to connect to
  */
 async function getAccessToken(url) {
+  if (!process.env.REQUIRE_AUTH_FOR_OUTGOING || process.env.REQUIRE_AUTH_FOR_OUTGOING === 'false')
+    return '';
+
   const server = servers.getServerByUrl(url);
   if (!server?.token || server?.tokenExp < Date.now()) {
     // create a new token if possible

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -65,7 +65,7 @@ async function connectToServer(url) {
  * @param {string} url - the base url of the server to connect to
  */
 async function getAccessToken(url) {
-  if (!process.env.REQUIRE_AUTH_FOR_OUTGOING || process.env.REQUIRE_AUTH_FOR_OUTGOING === 'false')
+  if (process.env.REQUIRE_AUTH_FOR_OUTGOING && process.env.REQUIRE_AUTH_FOR_OUTGOING === 'false')
     return '';
 
   const server = servers.getServerByUrl(url);


### PR DESCRIPTION
- Added `REQUIRE_AUTH` and `REQUIRE_AUTH_FOR_OUTGOING` environment variables.
- If set to `false`, the app will authorize all requests and not retrieve access tokens for outgoing requests.