### PR TITLE
Fetch resources in create-report action

### DIFF
--- a/src/utils/reporting_workflow.js
+++ b/src/utils/reporting_workflow.js
@@ -279,6 +279,11 @@ async function executeWorkflow(context) {
     const action = planDef.action.find(a => a.id === currentActionId);
     context.action = action;
 
+    if (action.action) {
+      // connectathon hack - merge everything from the nested action into this one
+      Object.assign(action, action.action[0]);
+    }
+
     const actionCode = context.action.code[0].coding[0].code;
     debug(`Executing ${actionCode} for PlanDefinition/${planDef.id}`);
 


### PR DESCRIPTION
Fetches resources as specified by the `PlanDefinition.action.input` field on the `create-report` action. Note that this should work when the trigger is a Patient or an Encounter, not sure about other resource types such as Condition yet. 

I used the attached encounter resource, pointing to all our internal FHIR servers, for testing:
[mitre_sample_enc.json.txt](https://github.com/mcode/medmorph-backend/files/6462135/mitre_sample_enc.json.txt)