### PR TITLE
Support variables in fhirpath using inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^4.17.1",
         "express-session": "^1.17.1",
         "fhir": "^4.8.2",
+        "fhirpath": "^2.8.0",
         "graphlib": "^2.1.8",
         "http-status-codes": "^2.1.4",
         "jwks-rsa": "^2.0.2",
@@ -2263,6 +2264,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/@lhncbc/ucum-lhc": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz",
+      "integrity": "sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==",
+      "dependencies": {
+        "csv-parse": "^4.4.6",
+        "csv-stringify": "^1.0.4",
+        "escape-html": "^1.0.3",
+        "is-integer": "^1.0.6",
+        "jsonfile": "^2.2.3",
+        "stream": "0.0.2",
+        "stream-transform": "^0.1.1",
+        "string-to-stream": "^1.1.0",
+        "xmldoc": "^0.4.0"
+      }
+    },
     "node_modules/@material-ui/core": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
@@ -3106,6 +3123,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/antlr4": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -4502,8 +4524,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -4697,8 +4718,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -4939,6 +4959,19 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.16.tgz",
       "integrity": "sha512-61FBWoDHp/gRtsoDkq/B1nWrCUG/ok1E3tUrcNbZjsE9Cxd9yzUirjS3+nAATB8U4cTtaQmAHbNndoFz5L6C9Q=="
     },
+    "node_modules/csv-parse": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.4.tgz",
+      "integrity": "sha512-OdBbFc0yZhOm17lSxqkirrHlFFVpKRT0wp4DAGoJelsP3LbGzV9LNr7XmM/lrr0uGkCtaqac9UhP8PDHXOAbMg=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
+      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+      "dependencies": {
+        "lodash.get": "~4.4.2"
+      }
+    },
     "node_modules/cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -4970,6 +5003,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -5317,6 +5355,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -6594,6 +6637,24 @@
       },
       "bin": {
         "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/fhirpath": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-2.8.0.tgz",
+      "integrity": "sha512-zxWHvEdvp6ySHaNADeOoLzg1iIz8m0vzFUKa+HHATkuJhv6PgK7neNxBMYq3COqF91WxdqewXvf+tvoTeAByVQ==",
+      "dependencies": {
+        "@lhncbc/ucum-lhc": "^4.1.3",
+        "antlr4": "~4.8.0",
+        "commander": "^2.18.0",
+        "date-fns": "^1.30.1",
+        "js-yaml": "^3.13.1"
+      },
+      "bin": {
+        "fhirpath": "bin/fhirpath"
+      },
+      "engines": {
+        "node": ">=8.9.0"
       }
     },
     "node_modules/figgy-pudding": {
@@ -7963,6 +8024,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8009,6 +8081,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "dependencies": {
+        "is-finite": "^1.0.0"
       }
     },
     "node_modules/is-negative-zero": {
@@ -8170,8 +8250,7 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -10045,6 +10124,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -10419,6 +10506,11 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -12212,8 +12304,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -13600,6 +13691,11 @@
         "which": "bin/which"
       }
     },
+    "node_modules/sax": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -14336,6 +14432,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "dependencies": {
+        "emitter-component": "^1.1.1"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -14423,6 +14527,11 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/stream-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
+      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
+    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -14471,6 +14580,37 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/string-to-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
+      "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0"
+      }
+    },
+    "node_modules/string-to-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/string-to-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -15828,8 +15968,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -17022,6 +17161,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xmldoc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
+      "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+      "dependencies": {
+        "sax": "~1.1.1"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -18855,6 +19002,22 @@
         }
       }
     },
+    "@lhncbc/ucum-lhc": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-4.1.4.tgz",
+      "integrity": "sha512-ErlXJv6lrerZbthxc33SWTKrZv4KjMIaCN2lNxsNrGZW4PqyVFEKDie6lok//SvC6QeEoAC1mWN8xD87r72qPQ==",
+      "requires": {
+        "csv-parse": "^4.4.6",
+        "csv-stringify": "^1.0.4",
+        "escape-html": "^1.0.3",
+        "is-integer": "^1.0.6",
+        "jsonfile": "^2.2.3",
+        "stream": "0.0.2",
+        "stream-transform": "^0.1.1",
+        "string-to-stream": "^1.1.0",
+        "xmldoc": "^0.4.0"
+      }
+    },
     "@material-ui/core": {
       "version": "4.11.3",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
@@ -19548,6 +19711,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "antlr4": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -20660,8 +20828,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -20833,8 +21000,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -21034,6 +21200,19 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.16.tgz",
       "integrity": "sha512-61FBWoDHp/gRtsoDkq/B1nWrCUG/ok1E3tUrcNbZjsE9Cxd9yzUirjS3+nAATB8U4cTtaQmAHbNndoFz5L6C9Q=="
     },
+    "csv-parse": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.15.4.tgz",
+      "integrity": "sha512-OdBbFc0yZhOm17lSxqkirrHlFFVpKRT0wp4DAGoJelsP3LbGzV9LNr7XmM/lrr0uGkCtaqac9UhP8PDHXOAbMg=="
+    },
+    "csv-stringify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",
+      "integrity": "sha1-d6QVJlgbzjOA8SsA18W7rHDIK1g=",
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -21059,6 +21238,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "debug": {
       "version": "2.6.9",
@@ -21361,6 +21545,11 @@
           "dev": true
         }
       }
+    },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
     },
     "emittery": {
       "version": "0.7.2",
@@ -22342,6 +22531,18 @@
             "sax": "^1.2.4"
           }
         }
+      }
+    },
+    "fhirpath": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/fhirpath/-/fhirpath-2.8.0.tgz",
+      "integrity": "sha512-zxWHvEdvp6ySHaNADeOoLzg1iIz8m0vzFUKa+HHATkuJhv6PgK7neNxBMYq3COqF91WxdqewXvf+tvoTeAByVQ==",
+      "requires": {
+        "@lhncbc/ucum-lhc": "^4.1.3",
+        "antlr4": "~4.8.0",
+        "commander": "^2.18.0",
+        "date-fns": "^1.30.1",
+        "js-yaml": "^3.13.1"
       }
     },
     "figgy-pudding": {
@@ -23402,6 +23603,11 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -23433,6 +23639,14 @@
       "requires": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
+      }
+    },
+    "is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "requires": {
+        "is-finite": "^1.0.0"
       }
     },
     "is-negative-zero": {
@@ -23540,8 +23754,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -24959,6 +25172,14 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -25282,6 +25503,11 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
       "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -26705,8 +26931,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -27818,6 +28043,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
+      "integrity": "sha1-XWFr6KXmB9VOEUr65Vt+ry/MMkA="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -28421,6 +28651,14 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -28512,6 +28750,11 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "stream-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-0.1.2.tgz",
+      "integrity": "sha1-fY5rTgOsR4F3j4x5UXUBv7B2Kp8="
+    },
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -28542,6 +28785,39 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string-to-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-1.1.1.tgz",
+      "integrity": "sha512-QySF2+3Rwq0SdO3s7BAp4x+c3qsClpPQ6abAmb0DGViiSBAkT5kL6JT2iyzEVP+T1SmzHrQD1TwlP9QAHCc+Sw==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "string-width": {
@@ -29577,8 +29853,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -30538,6 +30813,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xmldoc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.4.0.tgz",
+      "integrity": "sha1-0lciS+g5PqrL+DfvIn/Y7CWzaIg=",
+      "requires": {
+        "sax": "~1.1.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "fhir": "^4.8.2",
+    "fhirpath": "^2.8.0",
     "graphlib": "^2.1.8",
     "http-status-codes": "^2.1.4",
     "jwks-rsa": "^2.0.2",

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -3,12 +3,8 @@ const { StatusCodes } = require('http-status-codes');
 const db = require('../storage/DataAccess');
 const { startReportingWorkflow } = require('../utils/reporting_workflow');
 const { getServerById, getEHRServer } = require('../storage/servers');
-const {
-  postSubscriptionsToEHR,
-  getBaseUrlFromFullUrl,
-  getPlanDef,
-  fetchEndpoint
-} = require('../utils/fhir');
+const { postSubscriptionsToEHR, getBaseUrlFromFullUrl, getPlanDef } = require('../utils/fhir');
+const { fetchEndpoint, fetchValueSets } = require('../utils/knowledgeartifacts');
 const { subscriptionsFromPlanDef, topicToResourceType } = require('../utils/subscriptions');
 const { PLANDEFINITIONS } = require('../storage/collections');
 const { default: base64url } = require('base64url');
@@ -139,6 +135,8 @@ function knowledgeArtifactFullResourceHandler(planDefinitions, serverUrl, res) {
     );
 
     fetchEndpoint(serverUrl, planDefinition);
+
+    fetchValueSets(serverUrl, planDefinition, null);
 
     const subscriptions = subscriptionsFromPlanDef(planDefinition, serverUrl);
     postSubscriptionsToEHR(subscriptions);

--- a/src/storage/collections.js
+++ b/src/storage/collections.js
@@ -3,6 +3,7 @@ module.exports = {
   PLANDEFINITIONS: 'plandefinitions',
   SUBSCRIPTIONS: 'subscriptions',
   ENDPOINTS: 'endpoints',
+  VALUESETS: 'valuesets',
   COMPLETED_REPORTS: 'completedreports',
   REPORTING: 'reporting',
   LOGS: 'logs',

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -393,7 +393,7 @@ function createBundle(records, type) {
   return bundle;
 }
 
-function evaluateExpression(expression, resources, variables={}) {
+function evaluateExpression(expression, resources, variables = {}) {
   if (expression.language === 'text/fhirpath') {
     const path = fhirpath.evaluate(resources, expression.expression, variables);
     return path;

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -60,17 +60,20 @@ const baseIgActions = {
 
         const query = type + '?' + params.join('&');
         const bundle = (await readFromEHR(query)).data;
+        let results = [];
 
-        let results = bundle.entry.map(e => e.resource);
+        if (bundle.entry) {
+          results = bundle.entry.map(e => e.resource);
 
-        if (codeFilter) {
-          // Can there be multiple codeFilters?
-          const { path, valueSet } = codeFilter[0];
-          const vsResource = db.select(VALUESETS, v => v.url === valueSet)[0];
-          // Filter resources that are in valueSet
-          results = results.filter(r =>
-            r[path].coding.some(c => checkCodeInVs(c.code, c.system, vsResource))
-          );
+          if (codeFilter) {
+            // Can there be multiple codeFilters?
+            const { path, valueSet } = codeFilter[0];
+            const vsResource = db.select(VALUESETS, v => v.url === valueSet)[0];
+            // Filter resources that are in valueSet
+            results = results.filter(r =>
+              r[path].coding.some(c => checkCodeInVs(c.code, c.system, vsResource))
+            );
+          }
         }
 
         variables[id] = results;

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -54,10 +54,11 @@ function generateOperationOutcome(code, msg) {
  *
  * @param {string} server - the sourse server base url
  * @param {string} resourceType - the type of the resource
+ * @param {string} query - any query to append to the search. default "_include-*"
  * @returns axios promise of FHIR bundle of resources
  */
-async function getResources(server, resourceType) {
-  const url = `${server}/${resourceType}?_include=*`;
+async function getResources(server, resourceType, query = '_include=*') {
+  const url = `${server}/${resourceType}?${query}`;
   const token = await getAccessToken(server, db);
   const headers = { Authorization: `Bearer ${token}` };
   const axiosResponse = axios

--- a/src/utils/knowledgeartifacts.js
+++ b/src/utils/knowledgeartifacts.js
@@ -1,7 +1,8 @@
 const debug = require('../storage/logs').debug('medmorph-backend:fhir');
+const error = require('../storage/logs').error('medmorph-backend:fhir');
 const db = require('../storage/DataAccess');
 const { subscriptionsFromBundle } = require('./subscriptions');
-const { SERVERS, ENDPOINTS } = require('../storage/collections');
+const { SERVERS, ENDPOINTS, VALUESETS } = require('../storage/collections');
 const { EXTENSIONS, getResources, getReferencedResource } = require('./fhir');
 
 /**
@@ -25,8 +26,10 @@ function refreshKnowledgeArtifact(server) {
       subscriptionsFromBundle(bundle, server.endpoint);
 
       bundle.entry.forEach(async entry => {
-        if (entry.resource.resourceType === 'PlanDefinition')
+        if (entry.resource.resourceType === 'PlanDefinition') {
           fetchEndpoint(server.endpoint, entry.resource);
+          fetchValueSets(server.endpoint, entry.resource, bundle);
+        }
       });
     }
   });
@@ -49,6 +52,71 @@ function fetchEndpoint(url, planDefinition) {
 }
 
 /**
+ * Fetches any referenced ValueSets from the planDefinition and saves to the database
+ *
+ * @param {string} url - fhir server base url to fetch from
+ * @param {PlanDefinition} planDefinition - PlanDefinition to search for referenced ValueSets
+ * @param {Bundle} bundle - the Bundle the PlanDefinition was returned in,
+ *                          in case it already contains the VS we want
+ */
+async function fetchValueSets(url, planDefinition, bundle) {
+  const valueSets = new Set();
+
+  if (planDefinition.relatedArtifact) {
+    for (const relatedArtifact of planDefinition.relatedArtifact) {
+      // TODO: seems like there are a lot of ways that we might need to fetch a VS
+      // for now just assume it will be referenced in the resource field.
+      // further, there is no guaranteed way to know what is being referenced is a VS
+      // so let's just check the URL and hope it contains the string ValueSet
+      if (relatedArtifact.resource?.toLowerCase().includes('valueset')) {
+        valueSets.add(relatedArtifact.resource);
+      }
+    }
+  }
+
+  for (const action of planDefinition.action) {
+    // TODO: anywhere else that value sets can be referenced?
+    // currently this only looks at PlanDef.action.input.codeFilter.valueSet
+
+    if (action.input) {
+      for (const input of action.input) {
+        if (input.codeFilter) {
+          for (const codeFilter of input.codeFilter) {
+            if (codeFilter.valueSet) {
+              valueSets.add(codeFilter.valueSet);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  for (const vs of valueSets) {
+    let vsResource;
+
+    if (bundle) {
+      vsResource = bundle.entry.find(
+        e => e.resource.resourceType === 'ValueSet' && e.resource.url === vs
+      );
+    }
+
+    if (!vsResource) {
+      const kaSearch = await getResources(url, 'ValueSet', `url=${vs}`);
+      if (kaSearch?.entry) {
+        vsResource = kaSearch.entry[0].resource;
+      }
+    }
+
+    if (vsResource) {
+      db.upsert(VALUESETS, vsResource, v => v.url === vsResource.url);
+      debug(`ValueSet/${vsResource.url} saved to db`);
+    } else {
+      error(`Unable to locate ValueSet ${vs}`);
+    }
+  }
+}
+
+/**
  * Extracts the Endpoint reference from the receiver address extension of the PlanDefinition
  *
  * @param {PlanDefinition} planDefinition - PlanDefinitions to extract from
@@ -61,6 +129,7 @@ function getReceiverAddress(planDefinition) {
 
 module.exports = {
   fetchEndpoint,
+  fetchValueSets,
   getReceiverAddress,
   refreshAllKnowledgeArtifacts,
   refreshKnowledgeArtifact

--- a/src/utils/valueSetUtils.js
+++ b/src/utils/valueSetUtils.js
@@ -1,11 +1,3 @@
-const fs = require('fs');
-
-function loadJsonVs(absoluteFilepath) {
-  const vsData = fs.readFileSync(absoluteFilepath);
-  const vsJson = JSON.parse(vsData);
-  return vsJson;
-}
-
 /**
  * Check if code is in value set
  * @param {string} code value to look for in a valueset

--- a/src/utils/valueSetUtils.js
+++ b/src/utils/valueSetUtils.js
@@ -6,19 +6,20 @@
  * @return {boolean} true if condition is in valueSet's compose block or expansion block
  */
 const checkCodeInVs = (code, codeSystem, valueSet) => {
+  if (!code || !codeSystem) return false;
+
   let inVSExpansion = false;
   let inVSCompose = false;
   if (valueSet.expansion) {
     // If valueSet has expansion, we only need to check these codes
     inVSExpansion = valueSet.expansion.contains.some(containsItem => {
-      if (!code || !codeSystem || !containsItem || !containsItem.system) return false;
+      if (!containsItem || !containsItem.system) return false;
       return code === containsItem.code && codeSystem === containsItem.system;
     });
   } else {
     // Checks if code is in any of the valueSet.compose.include arrays
     inVSCompose = valueSet.compose.include.some(includeItem => {
-      if (!code || !codeSystem || !includeItem || !includeItem.system || !includeItem.concept)
-        return false;
+      if (!includeItem || !includeItem.system || !includeItem.concept) return false;
       return (
         includeItem.system === codeSystem &&
         includeItem.concept.map(concept => concept.code).includes(code)

--- a/src/utils/valueSetUtils.js
+++ b/src/utils/valueSetUtils.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+
+function loadJsonVs(absoluteFilepath) {
+  const vsData = fs.readFileSync(absoluteFilepath);
+  const vsJson = JSON.parse(vsData);
+  return vsJson;
+}
+
+/**
+ * Check if code is in value set
+ * @param {string} code value to look for in a valueset
+ * @param {string} codeSystem the system to which the code value belongs
+ * @param {string} valueSet value set to be searched
+ * @return {boolean} true if condition is in valueSet's compose block or expansion block
+ */
+const checkCodeInVs = (code, codeSystem, valueSet) => {
+  let inVSExpansion = false;
+  let inVSCompose = false;
+  if (valueSet.expansion) {
+    // If valueSet has expansion, we only need to check these codes
+    inVSExpansion = valueSet.expansion.contains.some(containsItem => {
+      if (!code || !codeSystem || !containsItem || !containsItem.system) return false;
+      return code === containsItem.code && codeSystem === containsItem.system;
+    });
+  } else {
+    // Checks if code is in any of the valueSet.compose.include arrays
+    inVSCompose = valueSet.compose.include.some(includeItem => {
+      if (!code || !codeSystem || !includeItem || !includeItem.system || !includeItem.concept)
+        return false;
+      return (
+        includeItem.system === codeSystem &&
+        includeItem.concept.map(concept => concept.code).includes(code)
+      );
+    });
+  }
+
+  return inVSCompose || inVSExpansion;
+};
+
+module.exports = {
+  checkCodeInVs
+};


### PR DESCRIPTION
A joint effort with @danlee1025.

This PR adds support for querying and filtering resources by valueset, and plugging them into fhirpath expressions, for use in the `check-trigger-codes` action.

Two sample resources for testing (based on patients in the internal pathways.mitre.org EHR):
 - an encounter for a patient that has a condition with code "408643008", so this encounter should match the trigger codes and proceed with reporting [mitre_sample_enc_match.json.txt](https://github.com/mcode/medmorph-backend/files/6473693/mitre_sample_enc_match.json.txt)

- an encounter for a patient that has no conditions in the valueset, so this encounter should not match the trigger codes, and the reporting workflow should stop [mitre_sample_enc_no_match.json.txt](https://github.com/mcode/medmorph-backend/files/6473694/mitre_sample_enc_no_match.json.txt)
