### PR TITLE
Fix fetch-ka bug

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -6,11 +6,8 @@ const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 const testService = require('../services/test_service');
 const publicKey = require('../keys/publicKey.json');
-const {
-  refreshAllKnowledgeArtifacts,
-  getPlanDef,
-  getBaseUrlFromFullUrl
-} = require('../utils/fhir');
+const { getPlanDef, getBaseUrlFromFullUrl } = require('../utils/fhir');
+const { refreshAllKnowledgeArtifacts } = require('../utils/knowledgeartifacts');
 const { startReportingWorkflow } = require('../utils/reporting_workflow');
 
 router.get('/', testService);


### PR DESCRIPTION
When the refreshAllKnowledgeArtifacts function was moved from `utils/fhir` to `utils/knowledgeartifact` the import in `index.js` was not updated. I'm not sure why this wasn't caught by lint etc, but this fix allows that route to work again.