### PR TITLE
normalize urls when compared

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ DEBUG=medmorph-backend:*
 
 | CONFIG | Required | Description |
 | ------ | -------- | ----------- |
-
 | DATA_TRUST_SERVICE | Yes | The base url for the data/trust service server. |
 | ADMIN_TOKEN | No | The value of the admin token to bypass authorization. If unset no admin token can be used. |
 | REQUIRE_AUTH | No | If false, an access token will not be required to make requests. Defaults to true if unset.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "morgan": "~1.9.1",
         "node-jose": "^2.0.0",
         "nodemon": "^2.0.7",
+        "normalize-url": "^4.5.0",
         "passport": "^0.4.1",
         "passport-jwt": "^4.0.0",
         "passport-local": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "morgan": "~1.9.1",
     "node-jose": "^2.0.0",
     "nodemon": "^2.0.7",
+    "normalize-url": "^4.5.0",
     "passport": "^0.4.1",
     "passport-jwt": "^4.0.0",
     "passport-local": "^1.0.0",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ const publicKey = require('../keys/publicKey.json');
 const { getPlanDef, getBaseUrlFromFullUrl } = require('../utils/fhir');
 const { refreshAllKnowledgeArtifacts } = require('../utils/knowledgeartifacts');
 const { startReportingWorkflow } = require('../utils/reporting_workflow');
+const { compareUrl } = require('../utils/url');
 
 router.get('/', testService);
 
@@ -31,10 +32,8 @@ router.post('/trigger', (req, res) => {
   if (!resource.id) resource.id = uuidv4();
   const resourceFullUrl = `${process.env.BASE_URL}/${resource.resourceType}/${resource.id}`;
   const collection = `${resource.resourceType.toLowerCase()}s`;
-  db.upsert(
-    collection,
-    { fullUrl: resourceFullUrl, ...resource },
-    r => r.fullUrl === resourceFullUrl
+  db.upsert(collection, { fullUrl: resourceFullUrl, ...resource }, r =>
+    compareUrl(r.fullUrl, resourceFullUrl)
   );
 
   startReportingWorkflow(planDef, kaBaseUrl, resource);

--- a/src/services/messaging.js
+++ b/src/services/messaging.js
@@ -3,6 +3,7 @@ const { generateOperationOutcome, forwardMessageResponse } = require('../utils/f
 const debug = require('../storage/logs').debug('medmorph-backend:messaging');
 const db = require('../storage/DataAccess');
 const { MESSAGES } = require('../storage/collections');
+const { compareUrl } = require('../utils/url');
 
 function processMessage(req, res) {
   // Validate the message bundle
@@ -40,7 +41,7 @@ function processMessage(req, res) {
   }
 
   const fullUrl = `${messageHeader.source.endpoint}/Bundle/${messageBundle.id}`;
-  db.upsert(MESSAGES, { fullUrl, ...messageBundle }, r => r.fullUrl === fullUrl);
+  db.upsert(MESSAGES, { fullUrl, ...messageBundle }, r => compareUrl(r.fullUrl, fullUrl));
   debug(`Message bundle ${messageBundle.id} added to database`);
 
   forwardMessageResponse(messageBundle).then(() =>

--- a/src/services/subscriptions.js
+++ b/src/services/subscriptions.js
@@ -8,6 +8,7 @@ const { fetchEndpoint, fetchValueSets } = require('../utils/knowledgeartifacts')
 const { subscriptionsFromPlanDef, topicToResourceType } = require('../utils/subscriptions');
 const { PLANDEFINITIONS } = require('../storage/collections');
 const { default: base64url } = require('base64url');
+const { compareUrl } = require('../utils/url');
 const debug = require('../storage/logs').debug('medmorph-backend:subscriptions');
 const error = require('../storage/logs').error('medmorph-backend:subscriptions');
 
@@ -82,10 +83,8 @@ function reportTriggerFullResourceHandler(planDef, resources, resourceType, kaBa
     const resourceFullUrl = `${getEHRServer().endpoint}/${resourceType}/${resource.id}`;
     debug(`Received ${resourceType}/${resource.id} from subscription ${resourceFullUrl}`);
     const collection = `${resourceType.toLowerCase()}s`;
-    db.upsert(
-      collection,
-      { fullUrl: resourceFullUrl, ...resource },
-      r => r.fullUrl === resourceFullUrl
+    db.upsert(collection, { fullUrl: resourceFullUrl, ...resource }, r =>
+      compareUrl(r.fullUrl, resourceFullUrl)
     );
     startReportingWorkflow(planDef, kaBaseUrl, resource);
   });
@@ -125,10 +124,8 @@ function reportTriggerEmptyHandler(bundle, res) {
 function knowledgeArtifactFullResourceHandler(planDefinitions, serverUrl, res) {
   planDefinitions.forEach(async planDefinition => {
     const planDefinitionFullUrl = `${serverUrl}/PlanDefinition/${planDefinition.id}`;
-    db.upsert(
-      PLANDEFINITIONS,
-      { fullUrl: planDefinitionFullUrl, ...planDefinition },
-      r => r.fullUrl === planDefinitionFullUrl
+    db.upsert(PLANDEFINITIONS, { fullUrl: planDefinitionFullUrl, ...planDefinition }, r =>
+      compareUrl(r.fullUrl, planDefinitionFullUrl)
     );
     debug(
       `KA full-resource notification contained ${serverUrl}/PlanDefinition/${planDefinition.id}`

--- a/src/storage/logs.js
+++ b/src/storage/logs.js
@@ -2,6 +2,7 @@ const db = require('./DataAccess');
 const { LOGS, ERRORS, REQUESTS, NOTIFICATIONS } = require('./collections');
 const debugConsole = require('debug');
 const { v4: uuidv4 } = require('uuid');
+const normalizeUrl = require('normalize-url');
 
 function debug(location) {
   return message => {
@@ -45,10 +46,18 @@ function storeRequest(request) {
   if (modifiedBody.password) {
     delete modifiedBody.password;
   }
+  let url = '';
+  try {
+    // some request urls can't be normalized and
+    // throw an error
+    url = normalizeUrl(request.url);
+  } catch {
+    url = request.url;
+  }
   const log = {
     id: uuidv4(),
     timestamp: Date.now(),
-    url: request.url,
+    url: url,
     body: modifiedBody,
     headers: request.headers
   };

--- a/src/storage/servers.js
+++ b/src/storage/servers.js
@@ -1,7 +1,7 @@
 const { v4: uuidv4 } = require('uuid');
 const db = require('../storage/DataAccess');
 const { SERVERS } = require('./collections');
-
+const { compareUrl } = require('../utils/url');
 /**
  * Fields for Servers Data Types:
  *
@@ -34,7 +34,7 @@ function getServerById(id) {
 }
 
 function getServerByUrl(url) {
-  return db.select(SERVERS, s => s.endpoint === url)[0];
+  return db.select(SERVERS, s => compareUrl(s.endpoint, url))[0];
 }
 
 function deleteServer(id) {

--- a/src/utils/actions.js
+++ b/src/utils/actions.js
@@ -36,6 +36,7 @@ const configUtil = require('../storage/configUtil');
 const { forwardMessageResponse } = require('./fhir');
 const { COMPLETED_REPORTS, VALUESETS } = require('../storage/collections');
 const { checkCodeInVs } = require('./valueSetUtils');
+const { compareUrl } = require('../utils/url');
 const debug = require('../storage/logs').debug('medmorph-backend:actions');
 const error = require('../storage/logs').error('medmorph-backend:actions');
 const fhir = new Fhir();
@@ -68,7 +69,7 @@ const baseIgActions = {
           if (codeFilter) {
             // Can there be multiple codeFilters?
             const { path, valueSet } = codeFilter[0];
-            const vsResource = db.select(VALUESETS, v => v.url === valueSet)[0];
+            const vsResource = db.select(VALUESETS, v => compareUrl(v.url, valueSet))[0];
             // Filter resources that are in valueSet
             results = results.filter(r =>
               r[path].coding.some(c => checkCodeInVs(c.code, c.system, vsResource))
@@ -295,7 +296,7 @@ const baseIgActions = {
             const resource = e.resource;
             const collection = `${resource.resourceType.toLowerCase()}s`;
             const fullUrl = `${getEHRServer().endpoint}/${resource.resourceType}/${resource.id}`;
-            db.upsert(collection, { fullUrl, ...resource }, r => r.fullUrl === fullUrl);
+            db.upsert(collection, { fullUrl, ...resource }, r => compareUrl(r.fullUrl, fullUrl));
             return resource;
           });
 

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -5,6 +5,7 @@ const queryString = require('query-string');
 const keys = require('../keys/privateKey.json');
 const servers = require('../storage/servers');
 const configUtil = require('../storage/configUtil');
+const { compareUrl } = require('../utils/url');
 const error = require('../storage/logs').error('medmorph-backend:client');
 /**
  * Generate and return access token for the specified server. If tokenEndpoint
@@ -106,8 +107,8 @@ async function getTokenEndpoint(url) {
       const rest = response.data.rest;
       const serverRest = rest.find(r => r.mode === 'server');
       const extensions = serverRest.security.extension;
-      const oauth = extensions.find(
-        e => e.url === 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris'
+      const oauth = extensions.find(e =>
+        compareUrl(e.url, 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris')
       );
       return oauth.extension.find(e => e.url === 'token').valueUri;
     } catch (ex2) {

--- a/src/utils/reporting_workflow.js
+++ b/src/utils/reporting_workflow.js
@@ -6,6 +6,7 @@ const { getReceiverAddress } = require('../utils/knowledgeartifacts');
 const { getEHRServer } = require('../storage/servers');
 const { baseIgActions } = require('./actions');
 const { REPORTING, ENDPOINTS } = require('../storage/collections');
+const { compareUrl } = require('../utils/url');
 const debug = require('../storage/logs').debug('medmorph-backend:reporting_workflow');
 
 /*
@@ -80,7 +81,7 @@ async function startReportingWorkflow(planDef, serverUrl, resource = null) {
   let receiverAddress = getReceiverAddress(planDef);
   if (receiverAddress.split('/')[0] === 'Endpoint')
     receiverAddress = `${serverUrl}/${receiverAddress}`;
-  const endpoint = db.select(ENDPOINTS, e => e.fullUrl === receiverAddress);
+  const endpoint = db.select(ENDPOINTS, e => compareUrl(e.fullUrl, receiverAddress));
   const destEndpoint = endpoint[0].address;
 
   // QUESTION: Should encounter and patient be saved to the database?

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,9 @@
+const normalizeUrl = require('normalize-url');
+
+function compareUrl(url1, url2) {
+  return normalizeUrl(url1) === normalizeUrl(url2);
+}
+
+module.exports = {
+  compareUrl
+};


### PR DESCRIPTION
This introduces the `normalizeUrl` library to the backend.  Any instance of URLs being compared has been replaced with the `compareUrls` function which normalizes the urls before they're compared.  This should ensure consistency.  The normalize function does produce an error when it's fed a bad URL, and I was considering adding a try/catch, but there shouldn't be a situation (outside of the `storeRequests` function) where it's fed a bad url.