### PR TITLE
Dynamic client registration

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,7 +32,7 @@ const configInit = [
     description: 'Whether the BSA will fetch and use a token when making external requests'
   },
   {
-    id: configVars.DYANMIC_CLIENT_REGISTRATION,
+    id: configVars.DYNAMIC_CLIENT_REGISTRATION,
     value: false,
     display: 'Dynamic Client Registration',
     description: 'Whether the BSA will attempt to dynamically register with PHAs'

--- a/config.js
+++ b/config.js
@@ -2,14 +2,16 @@ const configVars = {
   ADMIN_TOKEN: 'admintoken',
   DATA_TRUST_SERVICE: 'datatrustservice',
   REQUIRE_AUTH: 'requireauth',
-  REQUIRE_AUTH_FOR_OUTGOING: 'requireauthout'
+  REQUIRE_AUTH_FOR_OUTGOING: 'requireauthout',
+  DYANMIC_CLIENT_REGISTRATION: 'dynamicclientregistration'
 };
 const configInit = [
   {
     id: configVars.ADMIN_TOKEN,
     value: 'admin',
     display: 'Admin token',
-    description: 'Allows incoming requests to use a fixed bearer token for testing the interactions, should be unset in production.'
+    description:
+      'Allows incoming requests to use a fixed bearer token for testing the interactions, should be unset in production.'
   },
   {
     id: configVars.DATA_TRUST_SERVICE,
@@ -28,6 +30,12 @@ const configInit = [
     value: true,
     display: 'Require auth out',
     description: 'Whether the BSA will fetch and use a token when making external requests'
+  },
+  {
+    id: configVars.DYANMIC_CLIENT_REGISTRATION,
+    value: false,
+    display: 'Dynamic Client Registration',
+    description: 'Whether the BSA will attempt to dynamically register with PHAs'
   }
 ];
 

--- a/config.js
+++ b/config.js
@@ -3,7 +3,7 @@ const configVars = {
   DATA_TRUST_SERVICE: 'datatrustservice',
   REQUIRE_AUTH: 'requireauth',
   REQUIRE_AUTH_FOR_OUTGOING: 'requireauthout',
-  DYANMIC_CLIENT_REGISTRATION: 'dynamicclientregistration'
+  DYNAMIC_CLIENT_REGISTRATION: 'dynamicclientregistration'
 };
 const configInit = [
   {

--- a/src/storage/configUtil.js
+++ b/src/storage/configUtil.js
@@ -7,12 +7,10 @@ const { configVars } = require('../../config');
  *
  * Server:
  *  @param {string} ADMIN_TOKEN - bearer token that grants access
- *  @param {string} AUTH_CERTS_URL: - auth url for certs retrieval
- *  @param {string} AUTH_TOKEN_URL - auth url for token retrieval
  *  @param {string} DATA_TRUST_SERVICE - the data trust service
  *  @param {string} REQUIRE_AUTH - require auth for incoming requests
  *  @param {string} REQUIRE_AUTH_FOR_OUTGOING - require auth for outgoing requests
- *
+ *  @param {string} DYANMIC_CLIENT_REGISTRATION - whether or not to attempt dynamic client registration
  *
  */
 
@@ -22,72 +20,34 @@ function getConfig() {
 
 function getAdminToken() {
   const selection = db.select(CONFIG, c => c.id === configVars.ADMIN_TOKEN)[0];
-  if (selection) {
-    return selection.value;
-  }
-}
-
-function setAdminToken(value) {
-  const entry = {
-    id: configVars.ADMIN_TOKEN,
-    value: value
-  };
-  db.upsert(CONFIG, entry, c => c.id === entry.id);
+  if (selection) return selection.value;
 }
 
 function getDataTrustService() {
   const selection = db.select(CONFIG, c => c.id === configVars.DATA_TRUST_SERVICE)[0];
-  if (selection) {
-    return selection.value;
-  }
+  if (selection) return selection.value;
 }
 
-function setDataTrustService(value) {
-  const entry = {
-    id: configVars.DATA_TRUST_SERVICE,
-    value: value
-  };
-  db.upsert(CONFIG, entry, c => c.id === entry.id);
+function getDynamicClientRegistration() {
+  const selection = db.select(CONFIG, c => c.id === configVars.DYANMIC_CLIENT_REGISTRATION)[0];
+  if (selection) return selection.value;
 }
 
 function getRequireAuth() {
   const selection = db.select(CONFIG, c => c.id === configVars.REQUIRE_AUTH)[0];
-  if (selection) {
-    return selection.value;
-  }
-}
-
-function setRequireAuth(value) {
-  const entry = {
-    id: configVars.REQUIRE_AUTH,
-    value: value
-  };
-  db.upsert(CONFIG, entry, c => c.id === entry.id);
+  if (selection) return selection.value;
 }
 
 function getRequireAuthForOutgoing() {
   const selection = db.select(CONFIG, c => c.id === configVars.REQUIRE_AUTH_FOR_OUTGOING)[0];
-  if (selection) {
-    return selection.value;
-  }
-}
-
-function setRequireAuthForOutgoing(value) {
-  const entry = {
-    id: configVars.REQUIRE_AUTH_FOR_OUTGOING,
-    value: value
-  };
-  db.upsert(CONFIG, entry, c => c.id === entry.id);
+  if (selection) return selection.value;
 }
 
 module.exports = {
   getConfig,
   getAdminToken,
   getDataTrustService,
+  getDynamicClientRegistration,
   getRequireAuth,
-  getRequireAuthForOutgoing,
-  setAdminToken,
-  setDataTrustService,
-  setRequireAuth,
-  setRequireAuthForOutgoing
+  getRequireAuthForOutgoing
 };

--- a/src/storage/configUtil.js
+++ b/src/storage/configUtil.js
@@ -10,7 +10,7 @@ const { configVars } = require('../../config');
  *  @param {string} DATA_TRUST_SERVICE - the data trust service
  *  @param {string} REQUIRE_AUTH - require auth for incoming requests
  *  @param {string} REQUIRE_AUTH_FOR_OUTGOING - require auth for outgoing requests
- *  @param {string} DYANMIC_CLIENT_REGISTRATION - whether or not to attempt dynamic client registration
+ *  @param {string} DYANMIC_CLIENT_REGISTRATION - whether to attempt dynamic client registration
  *
  */
 
@@ -21,6 +21,14 @@ function getConfig() {
 function getAdminToken() {
   const selection = db.select(CONFIG, c => c.id === configVars.ADMIN_TOKEN)[0];
   if (selection) return selection.value;
+}
+
+function setAdminToken(value) {
+  const entry = {
+    id: configVars.ADMIN_TOKEN,
+    value: value
+  };
+  db.upsert(CONFIG, entry, c => c.id === entry.id);
 }
 
 function getDataTrustService() {
@@ -49,5 +57,6 @@ module.exports = {
   getDataTrustService,
   getDynamicClientRegistration,
   getRequireAuth,
-  getRequireAuthForOutgoing
+  getRequireAuthForOutgoing,
+  setAdminToken
 };

--- a/src/storage/configUtil.js
+++ b/src/storage/configUtil.js
@@ -10,7 +10,7 @@ const { configVars } = require('../../config');
  *  @param {string} DATA_TRUST_SERVICE - the data trust service
  *  @param {string} REQUIRE_AUTH - require auth for incoming requests
  *  @param {string} REQUIRE_AUTH_FOR_OUTGOING - require auth for outgoing requests
- *  @param {string} DYANMIC_CLIENT_REGISTRATION - whether to attempt dynamic client registration
+ *  @param {string} DYNAMIC_CLIENT_REGISTRATION - whether to attempt dynamic client registration
  *
  */
 
@@ -37,7 +37,7 @@ function getDataTrustService() {
 }
 
 function getDynamicClientRegistration() {
-  const selection = db.select(CONFIG, c => c.id === configVars.DYANMIC_CLIENT_REGISTRATION)[0];
+  const selection = db.select(CONFIG, c => c.id === configVars.DYNAMIC_CLIENT_REGISTRATION)[0];
   if (selection) return selection.value;
 }
 

--- a/src/storage/servers.js
+++ b/src/storage/servers.js
@@ -31,8 +31,7 @@ function getServers() {
 }
 
 function getServerById(id) {
-  const server = db.select(SERVERS, s => s.id === id);
-  return server.length ? server[0] : null;
+  return db.select(SERVERS, s => s.id === id)[0];
 }
 
 function getServerByUrl(url) {

--- a/src/storage/servers.js
+++ b/src/storage/servers.js
@@ -23,6 +23,7 @@ function addServer(server) {
   }
 
   db.upsert(SERVERS, server, s => s.id === server.id);
+  return server;
 }
 
 function getServers() {
@@ -30,7 +31,8 @@ function getServers() {
 }
 
 function getServerById(id) {
-  return db.select(SERVERS, s => s.id === id)[0];
+  const server = db.select(SERVERS, s => s.id === id);
+  return server.length ? server[0] : null;
 }
 
 function getServerByUrl(url) {

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -109,6 +109,11 @@ async function registerServer(url) {
   };
 
   const registrationEndpoint = await getRegistrationEndpoint(url);
+  if (!registrationEndpoint) {
+    error(`Unable to register new server ${url}: dynamic registration not supported`);
+    return null;
+  }
+
   return axios
     .post(registrationEndpoint, metadata)
     .then(result => {
@@ -158,7 +163,7 @@ async function getTokenEndpoint(url) {
  * Get the registration_endpoint from the .well-known/smart-configuration
  *
  * @param {string} url - the fhir base url
- * @returns registration_endpoint
+ * @returns registration_endpoint or null if not found (not supported)
  */
 async function getRegistrationEndpoint(url) {
   try {
@@ -181,7 +186,7 @@ async function getRegistrationEndpoint(url) {
       // not sure what to do if both fail?
       error(ex);
       error(ex2);
-      throw ex2;
+      return null;
     }
   }
 }

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -123,7 +123,7 @@ async function registerServer(url) {
   return axios
     .post(registrationEndpoint, metadata)
     .then(result => {
-      debug(`Adding server with clientId: ${result.data.client_id}`);
+      debug(`Registered with new server: ${url}\n Received clientId: ${result.data.client_id}`);
       const server = { name: url, endpoint: url, type: 'PHA', clientId: result.data.client_id };
       return servers.addServer(server);
     })
@@ -221,4 +221,4 @@ async function generateJWT(client_id, aud) {
     .final();
 }
 
-module.exports = { getAccessToken };
+module.exports = { getAccessToken, registerServer };

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -98,7 +98,7 @@ async function getAccessToken(url) {
  * @returns the server object if successful, otherwise null
  */
 async function registerServer(url) {
-  if (configUtil.getDynamicClientRegistration() === 'false') return null;
+  if (configUtil.getDynamicClientRegistration() === false) return null;
 
   debug('Registering new server: ' + url);
   const metadata = {

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -98,6 +98,12 @@ async function getAccessToken(url) {
  * @returns the server object if successful, otherwise null
  */
 async function registerServer(url) {
+  if (
+    configUtil.getDynamicClientRegistration() &&
+    configUtil.getDynamicClientRegistration() === 'false'
+  )
+    return null;
+
   debug('Registering new server: ' + url);
   const metadata = {
     client_name: 'MITRE Medmorph Backend Service App',

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -98,11 +98,7 @@ async function getAccessToken(url) {
  * @returns the server object if successful, otherwise null
  */
 async function registerServer(url) {
-  if (
-    configUtil.getDynamicClientRegistration() &&
-    configUtil.getDynamicClientRegistration() === 'false'
-  )
-    return null;
+  if (configUtil.getDynamicClientRegistration() === 'false') return null;
 
   debug('Registering new server: ' + url);
   const metadata = {

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -55,7 +55,7 @@ async function connectToServer(url) {
   // end client_secret_basic logic
 
   // Get access token from auth server
-  return await axios
+  return axios
     .post(tokenEndpoint, queryString.stringify(props), headers)
     .then(response => response.data)
     .catch(err => error(`Error obtaining access token from ${tokenEndpoint}\n${err.message}`));
@@ -162,16 +162,13 @@ async function getTokenEndpoint(url) {
  */
 async function getRegistrationEndpoint(url) {
   try {
-    console.log(`getting registration endpoint via smart-config`);
     const response = await axios.get(`${url}/.well-known/smart-configuration`);
     return response.data.registration_endpoint;
   } catch (ex) {
-    console.log(`Unable to get registration endpoint via smart config. Trying via metadata`);
     try {
       // sometimes the smart-config is in a non-standard place,
       // so let's try the server capability statement
       const response = await axios.get(`${url}/metadata`);
-      console.log(`got metadata`);
 
       const rest = response.data.rest;
       const serverRest = rest.find(r => r.mode === 'server');
@@ -182,7 +179,6 @@ async function getRegistrationEndpoint(url) {
       return oauth.extension.find(e => e.url === 'register').valueUri;
     } catch (ex2) {
       // not sure what to do if both fail?
-      console.log(`both failed. woops`);
       error(ex);
       error(ex2);
       throw ex2;
@@ -209,7 +205,7 @@ async function generateJWT(client_id, aud) {
     jti: v4()
   });
 
-  return await jose.JWS.createSign(options, key)
+  return jose.JWS.createSign(options, key)
     .update(input)
     .final();
 }

--- a/src/utils/fhir.js
+++ b/src/utils/fhir.js
@@ -139,14 +139,11 @@ async function getReferencedResource(url, reference, parentResource, returnFullU
 
   const resource = await axios
     .get(requestUrl, { headers: headers })
-    .then(response => {
-      if (returnFullUrl) return { fullUrl: requestUrl, resource: response.data };
-      else return response.data;
-    })
+    .then(response => response.data)
     .catch(err => error(`Error getting referenced resource ${requestUrl}\n${err.message}`));
   if (resource) {
     debug(`Retrieved reference resource ${resource.resourceType}/${resource.id} from ${url}`);
-    return resource;
+    return returnFullUrl ? { fullUrl: requestUrl, resource: resource } : resource;
   } else return null;
 }
 

--- a/src/utils/knowledgeartifacts.js
+++ b/src/utils/knowledgeartifacts.js
@@ -6,6 +6,7 @@ const { SERVERS, ENDPOINTS, VALUESETS } = require('../storage/collections');
 const { EXTENSIONS, CODE_SYSTEMS, getResources, getReferencedResource } = require('./fhir');
 const { compareUrl } = require('../utils/url');
 const { registerServer } = require('./client');
+const { getServerByUrl } = require('../storage/servers');
 
 /**
  * Get all knowledge artifacts (from servers registered in the
@@ -59,7 +60,7 @@ function fetchEndpoint(url, planDefinition) {
       debug(`Endpoint/${endpoint.id} saved to db`);
 
       const baseUrl = endpoint.address.split('/$process-message')[0];
-      registerServer(baseUrl);
+      if (!getServerByUrl(baseUrl)) registerServer(baseUrl);
     }
   });
 }

--- a/src/utils/knowledgeartifacts.js
+++ b/src/utils/knowledgeartifacts.js
@@ -5,6 +5,7 @@ const { subscriptionsFromBundle } = require('./subscriptions');
 const { SERVERS, ENDPOINTS, VALUESETS } = require('../storage/collections');
 const { EXTENSIONS, CODE_SYSTEMS, getResources, getReferencedResource } = require('./fhir');
 const { compareUrl } = require('../utils/url');
+const { registerServer } = require('./client');
 
 /**
  * Get all knowledge artifacts (from servers registered in the
@@ -42,7 +43,8 @@ function refreshKnowledgeArtifact(server) {
 }
 
 /**
- * Fetchs the referenced Endpoint from receiver address extension and saves to the database
+ * Fetchs the referenced Endpoint from receiver address extension and saves to the database.
+ * Will also attempt dynamic client registration if enabled in the config.
  *
  * @param {string} url - the url to fetch from
  * @param {PlanDefinition} planDefinition - PlanDefinition to get Endpoint from or null if
@@ -55,6 +57,9 @@ function fetchEndpoint(url, planDefinition) {
     if (endpoint) {
       db.upsert(ENDPOINTS, endpoint, r => compareUrl(r.fullUrl, endpoint.fullUrl));
       debug(`Endpoint/${endpoint.id} saved to db`);
+
+      const baseUrl = endpoint.address.split('/$process-message')[0];
+      registerServer(baseUrl);
     }
   });
 }

--- a/src/utils/knowledgeartifacts.js
+++ b/src/utils/knowledgeartifacts.js
@@ -57,9 +57,9 @@ function fetchEndpoint(url, planDefinition) {
   getReferencedResource(url, endpointReference, planDefinition, true).then(endpoint => {
     if (endpoint) {
       db.upsert(ENDPOINTS, endpoint, r => compareUrl(r.fullUrl, endpoint.fullUrl));
-      debug(`Endpoint/${endpoint.id} saved to db`);
+      debug(`Endpoint/${endpoint.resource.id} saved to db`);
 
-      const baseUrl = endpoint.address.split('/$process-message')[0];
+      const baseUrl = endpoint.resource.address.split('/$process-message')[0];
       if (!getServerByUrl(baseUrl)) registerServer(baseUrl);
     }
   });


### PR DESCRIPTION
Attempt to register the client with the PHA using [OAuth 2.0 Dynamic Client Registration Spec](https://datatracker.ietf.org/doc/html/rfc7591). 

One big note about this: the spec is pretty loose on the client metadata. Keycloak only support OpenID which further restricts the OAuth 2.0 spec and does not work for the `client_credentials` grant flow required for SMART Backend Authorization. I set up an Okta authorization server to test this but:
1. It requires an extra metadata not defined in the spec called `application_type`. This must be set to `service` for the client to be registered as defined in the SMART Backend Auth spec. This extra information should not break anything else so I left it in there for now.
2. It does not support `jwks_uri`, only `jwks`. The SMART Backend Auth spec allows for `jwks` but `jwks_uri` is preferred as it allows keys to be rotated. Unfortunately there does not seem to be a way to determine which claims on the metadata an authorization server supports. 
3. It requires an access token on the registration endpoint. It seems like all of the identity management platforms require this, and thus are mostly intended for a developer to register an application and not a piece of software to register itself. 

Open to suggestions on what this PR should and should not include plus discussion on our own authorization server.