### PR TITLE
Add mitre docker-compose file

### DIFF
--- a/docker/mitre-docker-compose.yml
+++ b/docker/mitre-docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+  medmorph_backend:
+    image: medmorph_backend
+    container_name: medmorph_backend
+    restart: on-failure
+    ports:
+      - "3000:3000"
+    environment:
+      - DEBUG=medmorph-backend:*
+      - ADMIN_TOKEN=admin
+      - AUTH_CERTS_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protocol/openid-connect/certs
+      - AUTH_TOKEN_URL=http://moonshot-dev.mitre.org:8090/auth/realms/backend_app/protocol/openid-connect/token
+      - BASE_URL=http://pathways.mitre.org:3000
+      - DATA_TRUST_SERVICE=http://pathways.mitre.org:3005
+      - REQUIRE_AUTH=true
+      - REQUIRE_AUTH_FOR_OUTGOING=true


### PR DESCRIPTION
The CD on pathways.mitre.org for the backend does not work because the docker-compose file has the baseurl set to localhost. This adds a new docker-compose file with updated env like the aws one in the same directory. This file is identical to the `src/docker-compose.yml` except for changing `localhost` to `pathways.mitre.org`